### PR TITLE
Get disk metrics

### DIFF
--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -59,6 +59,10 @@ Resources:
             Resource:
               - arn:aws:s3::*:editorial-tools-integration-tests-dist/*
               - arn:aws:s3::*:pan-domain-auth-settings/*
+          - Effect: Allow
+            Action:
+              - cloudwatch:PutMetricData
+            Resource: "*"
       Roles:
         - !Ref EditorialToolsIntegrationTestsRole
     DependsOn: EditorialToolsIntegrationTestsRole
@@ -143,8 +147,7 @@ Resources:
           aws s3 cp s3://editorial-tools-integration-tests-dist/env.json /editorial-tools-integration-tests/env.json
 
           # set up crontab
-          CRONJOB="*/5 * * * * root /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1"
-          echo "${CRONJOB}" >> /etc/cron.d/run-integration-tests
+          echo "*/5 * * * * root /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1" >> /etc/cron.d/run-integration-tests
 
           # Run the tests
           /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1

--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -143,11 +143,11 @@ Resources:
           aws s3 cp s3://editorial-tools-integration-tests-dist/env.json /editorial-tools-integration-tests/env.json
 
           # set up crontab
-          (crontab -l | echo '*/5 * * * * cd /editorial-tools-integration-tests && ./scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1') | sort - | uniq - | crontab -
+          CRONJOB="*/5 * * * * root /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1"
+          echo "${CRONJOB}" >> /etc/cron.d/run-integration-tests
 
           # Run the tests
-          cd /editorial-tools-integration-tests
-          ./scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1
+          /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1
 
 
   ApplicationSecurityGroup:

--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -61,7 +61,8 @@ Resources:
               - arn:aws:s3::*:pan-domain-auth-settings/*
           - Effect: Allow
             Action:
-              - cloudwatch:PutMetricData
+            - cloudwatch:PutMetricData
+            - ec2:DescribeTags
             Resource: "*"
       Roles:
         - !Ref EditorialToolsIntegrationTestsRole
@@ -137,6 +138,8 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -ev
+
+          cfn-init -s ${AWS::StackId} -r LaunchConfig --region ${AWS::Region} || error_exit ''Failed to run cfn-init''
 
           # Set up the tests and their depedencies
           aws s3 cp s3://editorial-tools-integration-tests-dist/media-service/${Stage}/editorial-tools-integration-tests/editorial-tools-integration-tests.zip /tmp/editorial-tools-integration-tests.zip

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,6 +3,7 @@
 set -e
 
 ENV=${1:-dev}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 
 bold='\x1B[0;1m'
@@ -10,7 +11,7 @@ green='\x1B[0;32m'
 red='\x1B[0;31m'
 plain='\x1B[0m' # No Color
 
-GRID_ENV=$(cat cypress.env.json | grep baseUrl | cut -d ":" -f 2-)
+GRID_ENV=$(cat "${DIR}"/../cypress.env.json | grep baseUrl | cut -d ":" -f 2-)
 
 checkIfAbleToTalkToAWS() {
   if [[ ${ENV} == "dev" ]]; then
@@ -30,6 +31,6 @@ checkIfAbleToTalkToAWS() {
 
 checkIfAbleToTalkToAWS
 echo -e "Fetching cookie for environment: ${bold}${GRID_ENV}${plain}"
-ENV=${ENV} node src/utils/cookie.js > cookie.json
+ENV=${ENV} node "${DIR}"/../src/utils/cookie.js > "${DIR}"/../cookie.json
 
 echo -e "${green}Cookie fetched!${plain}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+set -e
 
 ENV=$1
-
-set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 ${DIR}/setup.sh "${ENV}"
 
 echo "$(date): Running integration tests"
 
+pushd "${DIR}"/../ 2&>1 /dev/null
 docker run -v $PWD:/e2e -w /e2e cypress/included:4.3.0
+popd


### PR DESCRIPTION
(cherry picking changes from https://github.com/guardian/editorial-tools-integration-tests/commits/sg-aa/get-disk-available-metrics)

Create a cron file at `/etc/cron.d/run-integration-tests` in launch configuration to avoid overwriting the crontab created by the AMIgo role to record disk metrics.