### PR TITLE
Add metadata to LaunchConfig and fix start script

### DIFF
--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -128,6 +128,12 @@ Resources:
           Value: editorial-tools-integration-tests
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
+    Metadata:
+      AWS::CloudFormation::Init:
+        config:
+          files:
+            /etc/cron.d/run-integration-tests:
+              content: !Sub "*/5 * * * * root /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1"
     Properties:
       ImageId: !Ref 'AMI'
       AssociatePublicIpAddress: true
@@ -148,9 +154,6 @@ Resources:
 
           # get envars
           aws s3 cp s3://editorial-tools-integration-tests-dist/env.json /editorial-tools-integration-tests/env.json
-
-          # set up crontab
-          echo "*/5 * * * * root /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1" >> /etc/cron.d/run-integration-tests
 
           # Run the tests
           /editorial-tools-integration-tests/scripts/start.sh ${Stage} >> /var/log/tests.log 2>&1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -9,6 +9,6 @@ ${DIR}/setup.sh "${ENV}"
 
 echo "$(date): Running integration tests"
 
-pushd "${DIR}"/../ 2&>1 /dev/null
+pushd "${DIR}"/../
 docker run -v $PWD:/e2e -w /e2e cypress/included:4.3.0
 popd


### PR DESCRIPTION
Previously, the cloud-init script would break due to the LaunchConfig not having any metadata. This appears to be a required property of the LaunchConfiguration resource when referring to it in cfn-init, so this adds it with some provisioning of the cronjob that runs the test.

Additionally, this fixes a bug in the start script where the `pushd` command wasn't piping to dev/null correctly.