### PR TITLE
Improve Grid test reliability

### DIFF
--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -52,7 +52,7 @@ describe('Grid Integration Tests', () => {
     cy.url().should('include', '/');
   });
 
-  it.only('edit the image description, byline, credit and copyright', () => {
+  it('edit the image description, byline, credit and copyright', () => {
     cy.visit(getImageURL());
 
     // Edit the description

--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -27,7 +27,7 @@ describe('Grid Integration Tests', () => {
   });
 
   it('Can find an image by ID in search', function () {
-    cy.get('gr-text-chip > .ng-pristine').type(getImageHash());
+    cy.get('[data-cy=image-search-input]').type(getImageHash());
     cy.wait(3);
     cy.get(`a.preview__link[href*="${getImageHash()}"]`).click();
     cy.wait(3);

--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -4,16 +4,10 @@ import { wait } from '../../utils/wait';
 
 const date = new Date().toString();
 // hash of the image in assets/prodmontestimage12345.png
-const prodhash = '0e019da30d5c429a98a3e9aabafe689576a6a4ba';
-const codehash = '8297d9e8825642feb236d1105f1c01b37e45089d';
+const imageHash = 'fe052e21c4bc4d76a2c841d97c5b2281cccd19bd';
 
 function getImageHash() {
-  const stage = Cypress.env('STAGE');
-  if (stage.toLowerCase() === 'prod') {
-    return prodhash;
-  } else {
-    return codehash;
-  }
+  return imageHash;
 }
 
 function getImageURL() {

--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -24,13 +24,15 @@ describe('Grid Integration Tests', () => {
   beforeEach(() => {
     checkVars();
     setCookie(cy);
+    cy.server();
+    cy.route(`/images/${getImageHash()}`).as('image');
   });
 
   it('Can find an image by ID in search', function () {
     cy.get('[data-cy=image-search-input]').type(getImageHash());
     cy.wait(3);
     cy.get(`a.preview__link[href*="${getImageHash()}"]`).click();
-    cy.wait(3);
+    cy.wait('@image');
     cy.url().should('equal', getImageURL());
   });
 
@@ -50,31 +52,44 @@ describe('Grid Integration Tests', () => {
     cy.url().should('include', '/');
   });
 
-  it('edit the image description, byline, credit and copyright', () => {
+  it.only('edit the image description, byline, credit and copyright', () => {
     cy.visit(getImageURL());
 
     // Edit the description
     cy.get('[data-cy=it-edit-description-button]').click({ force: true });
-    cy.get('.editable-has-buttons').clear().type(date);
-    cy.get('.editable-buttons > .button-save').click();
-    wait(3);
+    cy.get('[data-cy=metadata-description] .editable-has-buttons')
+      .clear()
+      .type(date);
+    cy.get(
+      '[data-cy=metadata-description] .editable-buttons > .button-save'
+    ).click();
 
     // Edit the byline
     cy.get('[data-cy=it-edit-byline-button]').click({ force: true });
-    cy.get('.editable-has-buttons').clear().type(date);
-    cy.get('.editable-buttons > .button-save').click();
-    wait(3);
+    cy.get('[data-cy=metadata-byline] .editable-has-buttons')
+      .clear()
+      .type(date);
+    cy.get(
+      '[data-cy=metadata-byline] .editable-buttons > .button-save'
+    ).click();
 
     // Edit the credit
     cy.get('[data-cy=it-edit-credit-button]').click({ force: true });
-    cy.get('.editable-has-buttons').clear().type(date);
-    cy.get('.editable-buttons > .button-save').click();
-    wait(3);
+    cy.get('[data-cy=metadata-credit] .editable-has-buttons')
+      .clear()
+      .type(date);
+    cy.get(
+      '[data-cy=metadata-credit] .editable-buttons > .button-save'
+    ).click();
 
     // Edit the copyright
     cy.get('[data-cy=it-edit-copyright-button]').click({ force: true });
-    cy.get('.editable-has-buttons').clear().type(date);
-    cy.get('.editable-buttons > .button-save').click();
+    cy.get('[data-cy=metadata-copyright] .editable-has-buttons')
+      .clear()
+      .type(date);
+    cy.get(
+      '[data-cy=metadata-copyright] .editable-buttons > .button-save'
+    ).click();
   });
 
   xit('add image to and remove image from a collection', () => {});


### PR DESCRIPTION
## What does this change?

Thanks to [this PR](https://github.com/guardian/grid/pull/2964) we now have better selectors for a lot of the elements being selected by these tests. Currently, these tests intermittently fail because the selectors being used are too general, and sometimes pick up two things rather than one.

This PR uses new selectors to ensure one specific thing is selected at a time, and uses [Cypress aliases](https://docs.cypress.io/guides/core-concepts/variables-and-aliases.html#Return-Values) to wait more intelligently.

## How can we measure success?

Integration tests still pass, and flake less (if not ever!!!)

## Images
