### PR TITLE
Small fixes and improvements to running in production

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.js
+++ b/cypress/integration/grid/keyUserJourneys.spec.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import 'cypress-file-upload';
 
 import { getDomain, setCookie } from '../../utils/networking';
-import { getImageHash, getImageURL } from './spec';
 import { checkVars } from '../../utils/vars';
+import { getImageHash, getImageURL } from '../../utils/grid/image';
 
 // ID of `cypress/fixtures/drag-n-drop.png`
 const id = '68991a0825f86a6b33ebcc6737bfe68340cd221f';

--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -1,18 +1,9 @@
-import { setCookie, getDomain } from '../../utils/networking';
+import { setCookie } from '../../utils/networking';
 import { checkVars } from '../../utils/vars';
 import { wait } from '../../utils/wait';
+import { getImageHash, getImageURL } from '../../utils/grid/image';
 
 const date = new Date().toString();
-// hash of the image in assets/GridmonTestImage.png
-export const imageHash = 'fe052e21c4bc4d76a2c841d97c5b2281cccd19bd';
-
-export function getImageHash() {
-  return imageHash;
-}
-
-export function getImageURL() {
-  return `${getDomain()}images/${getImageHash()}`;
-}
 
 describe('Grid Integration Tests', () => {
   beforeEach(() => {

--- a/cypress/utils/grid/image.js
+++ b/cypress/utils/grid/image.js
@@ -1,0 +1,12 @@
+import { getDomain } from '../networking';
+
+// hash of the image in assets/GridmonTestImage.png
+export const imageHash = 'fe052e21c4bc4d76a2c841d97c5b2281cccd19bd';
+
+export function getImageHash() {
+  return imageHash;
+}
+
+export function getImageURL() {
+  return `${getDomain()}images/${getImageHash()}`;
+}

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -2,7 +2,7 @@ const { baseUrls } = require('../../cypress.env.json');
 const { cookie, domain } = require(`../../cookie.json`);
 
 export function getDomain(prefix) {
-  const stage = Cypress.env('STAGE');
+  const stage = Cypress.env('STAGE').toLowerCase();
   const app = Cypress.env('APP');
   const appName = baseUrls[app] || app;
   const subdomain = prefix ? prefix + '.' + appName : appName;

--- a/reporters/pagerduty.js
+++ b/reporters/pagerduty.js
@@ -28,7 +28,14 @@ function Pagerduty(runner) {
   let failures = 0;
 
   runner.on('start', async function () {
-    fs.writeFileSync(failuresFile, '0');
+    // `scripts/run.sh` is responsible for cleaning up the failures file
+    // If one exists on start, it's because a
+    // previous test suite in the same app has run before this
+    if (fs.existsSync(failuresFile)) {
+      failures = fs.readFileSync(failuresFile);
+    } else {
+      fs.writeFileSync(failuresFile, '0');
+    }
   });
 
   runner.on('pending', async function (test) {


### PR DESCRIPTION
## What does this change?

There are a couple of problems that this PR solves:

* If you have multiple suites for one app (eg `grid/spec.js` and `grid/keyUserJourneys.spec.js`), the `pagerduty.js` reporter would recreate the failures file `grid.failures.txt` and start at 0. 
 - Since `scripts/run.sh` takes care of cleaning up the relevant failures file before running the tests, we can let `pagerduty.js` either create a new file if it doesn't exist or read from the existing file if a previous test has run.

Therefore, if you had failures in the first test suite and none in the second, videos would not be uploaded to S3 as the failures count would be reset by the `runner.on('start')` block
* In `keyUserJourneys.spec.js`, it looks like importing specific exports from `spec.js` somehow ends up importing the tests too, so running `keyUserJourneys' suite would run all tests from `spec.js` too.
  - By extracting the shared functions too `utils/grid/image.js`, we can safely import them into both suites without causing any issues with Cypress.
* `uploadVideo.js` was coupled to uploading videos named `spec.js`, and could not handle multiple video files for the same suite (eg with the Grid, which has `keyUserJourneys` and `spec` suites). Also, the videos had generic names and were not tied to the suite being run.
  - Now, we simply upload every video in the videos folder for the app being run, and also improve the naming of the file so they are easily identifiable in S3.

## How can we measure success?

* When a suite fails, videos get uploaded to S3
* Videos being uploaded to S3 have useful names
* The `keyUserJourneys` suite of tests only runs its suite, and not the tests from `spec.js`


## Images
