### PR TITLE
Fix names of videos uploaded to S3

### DIFF
--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -35,7 +35,7 @@ const date = now.getDate();
 
       await Promise.all(
         videos.map(async (video) => {
-          const key = `videos/${year}/${month}/${date}/${suite}-${video}-${new Date().toISOString()}.mp4`;
+          const key = `videos/${year}/${month}/${date}/${new Date().toISOString()}-${suite}-${video}`;
 
           await uploadVideoToS3({
             credentials,


### PR DESCRIPTION
## What does this change?

Uploading videos using the name of the video itself (with the `.mp4` extension) as part of the key resulted in a messy name in S3. This PR switches the order of the naming so it can both be sorted by date first and has a better name.

## How can we measure success?

## Images

Before
![image](https://user-images.githubusercontent.com/25747336/85154221-199b7380-b24f-11ea-920d-3fc247a882d8.png)

After
![image](https://user-images.githubusercontent.com/25747336/85154235-1e602780-b24f-11ea-978f-f692d4a4c8e6.png)
