### PR TITLE
Use better selector and make crop freeform

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.js
+++ b/cypress/integration/grid/keyUserJourneys.spec.js
@@ -43,18 +43,17 @@ describe('Grid Key User Journeys', function () {
     cy.url().should('equal', getImageURL());
 
     // Click on Crop button
-    cy.get('[ng-if="ctrl.canBeCropped"] > .titip-default').click();
+    cy.get('[data-cy=crop-image-button]').click();
     cy.wait(6000);
 
+    // Select freeform crop
+    cy.get('[data-cy=crop-options]').contains('freeform').click();
     // Edit x coordinate
     cy.get('[data-cy=crop-x-value-input]').clear().type(crop.xValue);
-
     // Edit y coordinate
     cy.get('[data-cy=crop-y-value-input]').clear().type(crop.yValue);
-
     // Edit width
     cy.get('[data-cy=crop-width-input]').clear().type(crop.width);
-
     // Edit height
     cy.get('[data-cy=crop-height-input]').clear().type(crop.height);
 


### PR DESCRIPTION
## What does this change?

To be merged after [this PR to add the necessary selector](https://github.com/guardian/grid/pull/2967).

One of the user journey tests fail in production because the crop values and coordinates get altered in the Grid due to it trying to enforce a landscape shape. This, in turn, results in a crop being created with landscape dimensions that are different to the dimensions we give it, making the assertion on the crop ID break.

By selecting the `freeform` crop option, this PR ensures that the crop created is exactly the size and dimensions we want. This has been tested locally and works perfectly.

## How can we measure success?

This test passes in PROD.

## Images
