### PR TITLE
Use better viewport size

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "video": true,
   "reporter": "reporters/pagerduty.js",
-  "viewportWidth": 1920,
-  "viewportHeight": 1080,
+  "viewportWidth": 1280,
+  "viewportHeight": 720,
   "videoCompression": false
 }


### PR DESCRIPTION
## What does this change?

It's still hard to make out what's going on in videos, partially due to using a _very_ high viewport resolution. 

Things will be less blurry if we drop the resolution of the viewport, and we gain little by having it so large in the first place, it was only chosen as it was the 1080p resolution and felt appropriate.

## How can we measure success?

Things are even easier to see!

## Images

Before:
![image](https://user-images.githubusercontent.com/25747336/85161821-4011dc80-b258-11ea-85e6-9445b7dac71b.png)

After:
![image](https://user-images.githubusercontent.com/25747336/85161877-5324ac80-b258-11ea-8c6b-f70c540b1aa8.png)
