### PR TITLE
Increase default timeout to 10 seconds

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "reporter": "reporters/pagerduty.js",
   "viewportWidth": 1920,
   "viewportHeight": 1080,
-  "videoCompression": false
+  "videoCompression": false,
+  "defaultCommandTimeout": 10000
 }


### PR DESCRIPTION
## What does this change?

[Cypress has a default timeout of 4 seconds for commands](https://docs.cypress.io/guides/references/configuration.html#Timeouts). Sometimes, the Grid takes a bit longer to perform certain commands, making tests sometimes fail and increase test flakiness.

This increases the default timeout to 10 seconds, giving Cypress a bit more time to wait. 

## How can we measure success?

Tests fail less often due to the Grid being a bit slow.

## Images
![image](https://user-images.githubusercontent.com/25747336/85287428-28bb3500-b48c-11ea-83c8-3542377c5e20.png)
