### PR TITLE
Wait for image to be searched for before clicking on it

### DIFF
--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -11,13 +11,14 @@ describe('Grid Integration Tests', () => {
     setCookie(cy);
     cy.server();
     cy.route(`/images/${getImageHash()}`).as('image');
+    cy.route(`/images?q=${getImageHash()}**`).as('searchForImage');
   });
 
   it('Can find an image by ID in search', function () {
-    cy.get('[data-cy=image-search-input]').type(getImageHash());
-    cy.wait(3);
-    cy.get(`a.preview__link[href*="${getImageHash()}"]`).click();
-    cy.wait('@image');
+    cy.get('[data-cy=image-search-input]')
+      .type(getImageHash() + '{enter}')
+      .wait('@searchForImage');
+    cy.get(`a.preview__link[href*="${getImageHash()}"]`).click().wait('@image');
     cy.url().should('equal', getImageURL());
   });
 


### PR DESCRIPTION
## What does this change?

The `Can find an image by ID in search` test is flaky. It looks like this is partially due to commands being run too early, such as trying to click on an image in a search before the image has been searched.

By aliasing the image search request, we can wait for the response before trying to click on the image. We can also enforce the search to start by pressing `{enter}` after the command, rather than rely on the Grid to work out that we've stopped typing.

## How can we measure success?

The test breaks less frequently due to the image not being searched first.

## Images
