### PR TITLE
Wait for image page to refresh twice before trying to delete label

### DIFF
--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -85,7 +85,8 @@ describe('Grid Integration Tests', () => {
     cy.get('[data-cy=it-add-label-button]').click();
     cy.get('.text-input').clear().type('someLabelHere');
     cy.get('.gr-add-label__form__buttons__button-save').click();
-    wait(1);
+    cy.wait('@image').wait('@image');
+    wait(2);
     cy.contains('someLabelHere')
       .parent()
       .find('[data-cy=it-remove-label-button]')


### PR DESCRIPTION
## What does this change?

It looks like the `add and remove labels from an image` test occasionally fails due to the label not being saved by the time the test tries to delete it. When debugging, it looks like the Grid makes two calls to the `/images/<HASH>` endpoint before the label is properly saved.

This PR improves the test by making it wait for the XHR `/images` response as well as waiting an extra 2 seconds, just in case the Grid is extra slow. 2 seconds feels like an acceptable amount of arbitrary wait time to me, but happy to discuss.

## How can we measure success?

The test stops failing due to trying to delete a label that hasn't been saved yet.

## Images

Evidence of the label still saving when trying to delete it.
![image](https://user-images.githubusercontent.com/25747336/85390593-eef83600-b540-11ea-811c-e5be02474c0a.png)
