### PR TITLE
Add comment explaining double wait

### DIFF
--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -85,6 +85,8 @@ describe('Grid Integration Tests', () => {
     cy.get('[data-cy=it-add-label-button]').click();
     cy.get('.text-input').clear().type('someLabelHere');
     cy.get('.gr-add-label__form__buttons__button-save').click();
+    // It looks like the Grid makes 2 XHR requests to the @image alias before the label is saved,
+    // so we wait twice with an extra 2 seconds to be extra safe
     cy.wait('@image').wait('@image');
     wait(2);
     cy.contains('someLabelHere')

--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -85,11 +85,11 @@ describe('Grid Integration Tests', () => {
     cy.get('[data-cy=it-add-label-button]').click();
     cy.get('.text-input').clear().type('someLabelHere');
     cy.get('.gr-add-label__form__buttons__button-save').click();
-    // It looks like the Grid makes 2 XHR requests to the @image alias before the label is saved,
-    // so we wait twice with an extra 2 seconds to be extra safe
-    cy.wait('@image').wait('@image');
-    wait(2);
-    cy.contains('someLabelHere')
+    cy.get('.labeller')
+      .contains('someLabelHere', { timeout: 5000 })
+      .should('exist');
+    cy.get('.labeller')
+      .contains('someLabelHere')
       .parent()
       .find('[data-cy=it-remove-label-button]')
       .click();


### PR DESCRIPTION
## What does this change?

Re: https://github.com/guardian/editorial-tools-integration-tests/pull/25#discussion_r444115088

Adding a comment to explain double-wait. 

## How can we measure success?

## Images
