### PR TITLE
Fetch cookie from within the tests!

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.js
+++ b/cypress/integration/grid/keyUserJourneys.spec.js
@@ -14,6 +14,12 @@ const date = new Date().toString();
 axios.defaults.withCredentials = true;
 
 describe('Grid Key User Journeys', function () {
+  before(() => {
+    cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
+      setCookie(cy, cookie);
+    });
+  });
+
   beforeEach(() => {
     checkVars();
     setCookie(cy);

--- a/cypress/integration/grid/spec.js
+++ b/cypress/integration/grid/spec.js
@@ -6,6 +6,14 @@ import { getImageHash, getImageURL } from '../../utils/grid/image';
 const date = new Date().toString();
 
 describe('Grid Integration Tests', () => {
+  before(() => {
+    before(() => {
+      cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
+        setCookie(cy, cookie);
+      });
+    });
+  });
+
   beforeEach(() => {
     checkVars();
     setCookie(cy);

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -18,4 +18,10 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on('task', {
+    async getCookie(stage) {
+      const { cookie } = require('../../src/utils/cookie.js');
+      return await cookie(stage, false);
+    },
+  });
 };

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -13,9 +13,11 @@ export function getDomain(prefix) {
   }
 }
 
-export function setCookie(cy) {
-  cy.setCookie('gutoolsAuth-assym', cookie, {
-    domain: `.${domain}`,
+export function setCookie(cy, overrides) {
+  const cookieToSet = overrides ? overrides.cookie : cookie;
+  const domainToSet = overrides ? overrides.domain : domain;
+  cy.setCookie('gutoolsAuth-assym', cookieToSet, {
+    domain: `.${domainToSet}`,
     path: '/',
     secure: true,
     httpOnly: true,

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -58,21 +58,34 @@ function checkVars() {
   }
 }
 
-(async function main() {
+async function cookie(stageArg = undefined, writeToFile = true) {
   try {
     checkVars();
-    const stage = process.env['STAGE'];
+    const stage = stageArg || process.env['STAGE'];
     const domain = getDomain(stage);
     const cookie = await getCookie(domain).catch((err) => {
       console.log(`Received an error - please check you can access ${domain}`);
       console.error(err);
       process.exit(1);
     });
-    fs.writeFileSync(
-      path.join(__dirname, `../../cookie.json`),
-      JSON.stringify({ cookie, domain })
-    );
+    if (writeToFile) {
+      fs.writeFileSync(
+        path.join(__dirname, `../../cookie.json`),
+        JSON.stringify({ cookie, domain })
+      );
+    }
+
+    return { cookie, domain };
   } catch (err) {
     console.error(err);
   }
-})();
+}
+
+// Only call function if script is called directly
+if (require.main === module) {
+  (async function main() {
+    await cookie();
+  })();
+}
+
+module.exports = { cookie };


### PR DESCRIPTION
## What does this change?

Currently, we have to run a script to fetch the cookie before we run the tests. This causes issues when running the interactive test suite (`cypress open` or `scripts/dev.sh`) when the cookie expires or deletes itself while developing, and it would be better for the cookie fetching to happen every time the test suites were run.

Thanks to [Cypress tasks](https://docs.cypress.io/api/commands/task.html), now we can! This change fetches the cookie from **within the tests** every time a test suite is run.

## How can we measure success?

We can remove fetching the cookie as a separate step in a future PR and tests will still continue to run successfully with a valid cookie.

## Images
