### PR TITLE
Simplify cookie fetching and setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In the interests of keeping this repository organised, the best practice for add
 1. Add the required information to `cypress.env.json`. Keys in the file are ingested by the cookie generator script `src/utils/cookie.js`, 
 with the `baseUrl` of each being used to create a cookie. 
 Note that if you don't need a `gutools` cookie for your service, you can skip this step and reference the URL directly in the tests.
-    - In the below example, a cookie called `myNewService.cookie.json` would be created in the root of 
+    - In the below example, a `cookie.json` would be created in the root of 
 the repository, given the necessary `.settings` configuration file is found in the S3 bucket referenced in `env.json`.
     - The `.settings` config file looks at the third-level domain of the URL you are looking to hit, so, if your domain was `my-new-service.gutools.co.uk`, it would look for a settings file called `gutools.settings`.
     - For further information on how the cookie gets validated, please see the [pan-domain-node repository](https://github.com/guardian/pan-domain-authentication/#to-verify-login-in-nodejs) that `cookie.js` leverages to authenticate itself with Guardian domains.

--- a/cypress/integration/grid/keyUserJourneys.spec.js
+++ b/cypress/integration/grid/keyUserJourneys.spec.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import 'cypress-file-upload';
 
-import { setCookie, getDomain } from '../../utils/networking';
+import { getDomain, fetchAndSetCookie } from '../../utils/networking';
 import { checkVars } from '../../utils/vars';
 import { deleteImages, getImageHash, getImageURL } from '../../utils/grid/api';
 import * as uploads from '../../utils/grid/upload';
@@ -27,23 +27,17 @@ function setupAliases() {
 describe('Grid Key User Journeys', function () {
   before(() => {
     checkVars();
-    cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
-      setCookie(cy, cookie, false);
-      deleteImages(cy, [getImageHash()]);
-    });
+    fetchAndSetCookie();
+    deleteImages(cy, [getImageHash()]);
   });
 
   beforeEach(() => {
-    cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
-      setCookie(cy, cookie);
-    });
+    fetchAndSetCookie();
     setupAliases();
   });
 
   after(() => {
-    cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
-      setCookie(cy, cookie, false);
-    });
+    fetchAndSetCookie();
     deleteImages(cy, [getImageHash()]);
   });
 
@@ -73,7 +67,7 @@ describe('Grid Key User Journeys', function () {
     cy.get('[data-cy="upload-button"]').attachFile('GridmonTestImage.png', {
       subjectType: 'drag-n-drop',
     });
-    cy.get('ui-upload-jobs .result-editor__img', { timeout: 8000 }).should(
+    cy.get('ui-upload-jobs .result-editor__img', { timeout: 10000 }).should(
       'exist'
     );
     cy.then(async () => {
@@ -116,7 +110,7 @@ describe('Grid Key User Journeys', function () {
       waits.createCrop
     );
 
-    cy.url({ timeout: 5000 }).should(
+    cy.url({ timeout: 10000 }).should(
       'equal',
       `${getImageURL()}?crop=${cropID}`
     );

--- a/cypress/integration/grid/keyUserJourneys.spec.js
+++ b/cypress/integration/grid/keyUserJourneys.spec.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import 'cypress-file-upload';
 
-import { getDomain, setCookie } from '../../utils/networking';
+import { setCookie, getDomain } from '../../utils/networking';
 import { checkVars } from '../../utils/vars';
 import { deleteImages, getImageHash, getImageURL } from '../../utils/grid/api';
 import * as uploads from '../../utils/grid/upload';

--- a/cypress/utils/grid/api.js
+++ b/cypress/utils/grid/api.js
@@ -12,7 +12,6 @@ export function getImageURL() {
 }
 
 export async function deleteImages(cy, images) {
-  setCookie(cy, false);
   cy.then(async () => {
     await Promise.all(
       images.map((id) => {
@@ -22,10 +21,8 @@ export async function deleteImages(cy, images) {
           .catch((err) => {
             // If it's 404, it means the image doesn't exist (so it can't be deleted)
             if (err.response && err.response.status === 404) {
-              cy.log(`${id} doesn't exist in Grid`);
               return;
             }
-            cy.log(`Error deleting ${id}`, err.message);
             throw err;
           })
           .then((res) => expect(res.status, `Delete ${id}`).to.equal(202));

--- a/cypress/utils/grid/image.js
+++ b/cypress/utils/grid/image.js
@@ -54,7 +54,7 @@ module.exports = {
     cy.get('.gr-add-label__form__buttons__button-save')
       .click()
       .should('not.exist');
-    cy.get('.labeller').contains(name, { timeout: 5000 }).should('exist');
+    cy.get('.labeller').contains(name, { timeout: 10000 }).should('exist');
   },
 
   removeLabel(date) {

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -26,3 +26,11 @@ export function setCookie(cy, overrides, visitDomain = true) {
     cy.wait(2);
   }
 }
+
+export function fetchAndSetCookie() {
+  return cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
+    expect(cookie).to.have.property('cookie');
+    expect(cookie).to.have.property('domain');
+    return setCookie(cy, cookie, false);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "cookie": "node ./src/utils/cookie.js",
     "test": "./scripts/setup.sh $ENV && npm run cy:run-dev",
     "grid-prod": "APP=grid STAGE=prod npm run start",
     "grid-code": "APP=grid STAGE=test npm run start",
@@ -13,11 +12,11 @@
     "composer-prod": "APP=composer STAGE=prod npm run start",
     "composer-code": "APP=composer STAGE=code npm run start",
     "composer-local": "APP=composer STAGE=local npm run start",
-    "start": "npm run cookie && cypress run --reporter spec --env APP=$APP,STAGE=$STAGE --spec cypress/integration/$APP/*",
-    "cy:live": "npm run cookie && cypress run --env APP=$SUITE,STAGE=$STAGE --spec cypress/integration/$SUITE/*",
+    "start": "cypress run --reporter spec --env APP=$APP,STAGE=$STAGE --spec cypress/integration/$APP/*",
+    "cy:live": "cypress run --env APP=$SUITE,STAGE=$STAGE --spec cypress/integration/$SUITE/*",
     "cy:run-dev": "cypress run --reporter spec",
-    "cy:run": "npm run cookie && cypress run",
-    "cy:open": "npm run cookie && cypress open --env APP=$APP,STAGE=$STAGE",
+    "cy:run": "cypress run",
+    "cy:open": "cypress open --env APP=$APP,STAGE=$STAGE",
     "lint": "eslint cypress/integration/* src/* reporters",
     "riffraff": "node-riffraff-artifact",
     "upload-video": "node scripts/uploadVideo.js"

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -1,7 +1,4 @@
 const AWS = require('aws-sdk');
-
-const path = require('path');
-const fs = require('fs');
 const iniparser = require('iniparser');
 const { base64ToPEM } = require('@guardian/pan-domain-node/dist/src/utils');
 const { createCookie } = require('@guardian/pan-domain-node/dist/src/panda');
@@ -58,7 +55,7 @@ function checkVars() {
   }
 }
 
-async function cookie(stageArg = undefined, writeToFile = true) {
+async function cookie(stageArg = undefined) {
   try {
     checkVars();
     const stage = stageArg || process.env['STAGE'];
@@ -68,24 +65,11 @@ async function cookie(stageArg = undefined, writeToFile = true) {
       console.error(err);
       process.exit(1);
     });
-    if (writeToFile) {
-      fs.writeFileSync(
-        path.join(__dirname, `../../cookie.json`),
-        JSON.stringify({ cookie, domain })
-      );
-    }
 
     return { cookie, domain };
   } catch (err) {
     console.error(err);
   }
-}
-
-// Only call function if script is called directly
-if (require.main === module) {
-  (async function main() {
-    await cookie();
-  })();
 }
 
 module.exports = { cookie };


### PR DESCRIPTION
## What does this change?

Following on from [this PR](https://github.com/guardian/editorial-tools-integration-tests/pull/28), this PR cleans up old behaviour of getting a cookie and writing it to a file. Now, a cookie is fetched every time a test is run, removing unnecessary complexity and dependency on scripts being run before running the tests.

## How can we measure success?

Tests run reliably with cookie authentication both locally and in production!

## Images
