### PR TITLE
FIX: Don't require a now-unused cookie file

### DIFF
--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -1,5 +1,4 @@
 const { baseUrls } = require('../../cypress.env.json');
-const { cookie, domain } = require(`../../cookie.json`);
 
 export function getDomain(prefix) {
   const stage = Cypress.env('STAGE').toLowerCase();
@@ -11,11 +10,9 @@ export function getDomain(prefix) {
     : `https://${subdomain}.${stage}.dev-gutools.co.uk/`;
 }
 
-export function setCookie(cy, overrides, visitDomain = true) {
-  const cookieToSet = overrides ? overrides.cookie : cookie;
-  const domainToSet = overrides ? overrides.domain : domain;
-  cy.setCookie('gutoolsAuth-assym', cookieToSet, {
-    domain: `.${domainToSet}`,
+export function setCookie(cy, cookie, visitDomain = true) {
+  cy.setCookie('gutoolsAuth-assym', cookie.cookie, {
+    domain: `.${cookie.domain}`,
     path: '/',
     secure: true,
     httpOnly: true,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A previous commit removed the creation of a `cookie.json` file, this breaks repositories that don't have a leftover `cookie.json` file to import.

This PR enforces passing in the cookie and domain (which we already do) and stops errors from a require that doesn't do anything.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We can run the tests.

## What is the cost of failure?
<!-- Is this a critical path? Does failure costs money, violates law, ruins reputation? Do we need to alarm on failure? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
