### PR TITLE
Drop trailing slash from getDomain

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.js
+++ b/cypress/integration/grid/keyUserJourneys.spec.js
@@ -49,7 +49,7 @@ describe('Grid Key User Journeys', function () {
       yValue: '581',
     };
 
-    const cropsUrl = `${getDomain('cropper')}crops/${getImageHash()}`;
+    const cropsUrl = `${getDomain('cropper')}/crops/${getImageHash()}`;
 
     // For some reason, on production infrastructure, Cypress interacts with the browser differently and the crop.xValue gets reduced by 1.
     // This is a bug that should be investigated, but for now it's easier to just make a different assertion
@@ -72,7 +72,7 @@ describe('Grid Key User Journeys', function () {
     );
     cy.then(async () => {
       // Assert that image isn't usable before rights are added
-      const imageUrl = `${getDomain('api')}images/${dragImageID}`;
+      const imageUrl = `${getDomain('api')}/images/${dragImageID}`;
       let { usageRights } = (await axios.get(imageUrl)).data.data;
       expect(
         JSON.stringify(usageRights),
@@ -86,7 +86,7 @@ describe('Grid Key User Journeys', function () {
 
       cy.get(`ui-upload-jobs [href="/images/${dragImageID}"] img`).click();
       cy.url()
-        .should('equal', `${getDomain()}images/${dragImageID}`)
+        .should('equal', `${getDomain()}/images/${dragImageID}`)
         .then(async () => {
           // Assert that image is usable after rights are added
           usageRights = (await axios.get(imageUrl)).data.data.usageRights;
@@ -116,7 +116,7 @@ describe('Grid Key User Journeys', function () {
     );
 
     cy.then(async () => {
-      const url = `${getDomain('cropper')}crops/${getImageHash()}`;
+      const url = `${getDomain('cropper')}/crops/${getImageHash()}`;
       const cropsBeforeDelete = (await axios.get(url)).data.data;
       expect(
         cropsBeforeDelete.filter((ex) => ex.id === cropID).length,

--- a/cypress/utils/composer/expectPreview.js
+++ b/cypress/utils/composer/expectPreview.js
@@ -2,7 +2,7 @@ import { getDomain } from "../networking";
 import { getContent } from "./getContent";
 
 export async function expectPreview(id, regex) {
-    const url = `${getDomain()}api/content/${id}/preview`;
+    const url = `${getDomain()}/api/content/${id}/preview`;
     const data = await getContent(url);
     expect(data, "the data").to.not.be.null;
     const content1 = JSON.parse(data);

--- a/cypress/utils/grid/api.js
+++ b/cypress/utils/grid/api.js
@@ -8,14 +8,14 @@ export function getImageHash() {
 }
 
 export function getImageURL() {
-  return `${getDomain()}images/${getImageHash()}`;
+  return `${getDomain()}/images/${getImageHash()}`;
 }
 
 export async function deleteImages(cy, images) {
   cy.then(async () => {
     await Promise.all(
       images.map((id) => {
-        const url = `${getDomain('api')}images/${id}`;
+        const url = `${getDomain('api')}/images/${id}`;
         axios
           .delete(url)
           .catch((err) => {
@@ -33,7 +33,7 @@ export async function deleteImages(cy, images) {
 
 export async function uploadImage(cy, image) {
   setCookie(cy);
-  const url = `${getDomain('loader')}images`;
+  const url = `${getDomain('loader')}/images`;
   const res = await axios
     .post(url, image, { withCredentials: true })
     .catch(async (err) => {

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -6,8 +6,8 @@ export function getDomain(prefix) {
   const appName = baseUrls[app] || app;
   const subdomain = prefix ? prefix + '.' + appName : appName;
   return stage.toLowerCase() === 'prod'
-    ? `https://${subdomain}.gutools.co.uk/`
-    : `https://${subdomain}.${stage}.dev-gutools.co.uk/`;
+    ? `https://${subdomain}.gutools.co.uk`
+    : `https://${subdomain}.${stage}.dev-gutools.co.uk`;
 }
 
 export function setCookie(cy, cookie, visitDomain = true) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Before, the `getDomain()` function would return a URL with a trailing slash (eg `https://media.gutools.co.uk/`). This meant that, when using this function with different routes, we'd have to write something less legible like `const URL = "${getDomain()}images"` (but with back-ticks). 

As well as being harder to read, it prevents us from being flexible with the result of `getDomain`.

This PR refactors the function to drop the trailing slash and updates the usages to add trailing slashes.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

All tests continue to pass.

## What is the cost of failure?
<!-- Is this a critical path? Does failure costs money, violates law, ruins reputation? Do we need to alarm on failure? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
