### PR TITLE
Fix broken Composer test by adding a missing slash

### DIFF
--- a/cypress/utils/composer/getId.js
+++ b/cypress/utils/composer/getId.js
@@ -2,7 +2,7 @@ import {getDomain} from "../networking";
 
 export function getId(url) {
     const domain = getDomain();
-    expect(url).to.match( new RegExp(`${domain}content\/`));
+    expect(url).to.match( new RegExp(`${domain}/content\/`));
     return url.split('/')[4];
 }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A previous PR refactored the `getDomain()` function to drop the trailing slash from the URL it returns (eg `https://foo.com/` -> `https://foo.com`). When doing the refactor, this test assertion was missed, and it currently breaks. This PR adds the missing trailing slash to the string assertion.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The Composer test passes.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/25747336/87076131-348f5100-c219-11ea-8c48-c41fdad4a801.png)
