### PR TITLE
Catch another missing slash in getDomain

### DIFF
--- a/cypress/utils/composer/deleteArticle.js
+++ b/cypress/utils/composer/deleteArticle.js
@@ -1,13 +1,17 @@
-import { getDomain } from "../networking";
+import { getDomain } from '../networking';
 
 export function deleteArticle(id) {
-    return cy
-        .get(`a[href*="/content/${id}"]`).click()
-        .wait(2000)
-        .get('#js-management-edit').click()
-        .get('#js-content-information-delete').click({"force": true})
-        .get('#js-content-information-delete').click({"force": true})
-        .wait(2000)
-        .url().should('equal', `${getDomain()}`);
+  return cy
+    .get(`a[href*="/content/${id}"]`)
+    .click()
+    .wait(2000)
+    .get('#js-management-edit')
+    .click()
+    .get('#js-content-information-delete')
+    .click({ force: true })
+    .get('#js-content-information-delete')
+    .click({ force: true })
+    .wait(2000)
+    .url()
+    .should('equal', `${getDomain()}/`);
 }
-


### PR DESCRIPTION
## What does this change?

Following on from [this PR](https://github.com/guardian/editorial-tools-integration-tests/pull/33), `getDomain` drops the trailing slash from the URL it returns. This PR fixes another test that asserts based on the output of `getDomain`. It also prettifies the file based on the Prettier/ESLint config in the repository.

## How can we measure success?

The tests pass! They are currently passing locally against CODE and PROD, there was a bit of a chicken and egg situation with an other PR fixing cookie-fetching for composer tests, but this should now all be fixed.

## Have we considered potential risks?

## Images

![image](https://user-images.githubusercontent.com/25747336/87148297-10c61c80-c2a6-11ea-9110-d47ceefa385f.png)

