### PR TITLE
Refactor: Typescriptify the repository

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,16 +4,31 @@ module.exports = {
     es6: true,
     node: true,
   },
-  extends: ['google', 'prettier'],
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'google',
+    'prettier',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  overrides: [
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+  ],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
   },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   rules: {
     'require-jsdoc': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
   },
-}
+};

--- a/cypress/integration/composer/useCorrectFlag.ts
+++ b/cypress/integration/composer/useCorrectFlag.ts
@@ -1,32 +1,36 @@
 import { fetchAndSetCookie } from '../../utils/networking';
-import { checkVars } from "../../utils/vars";
-import { expectPreview } from "../../utils/composer/expectPreview";
-import { inATemporaryArticle } from "../../utils/composer/inATemporaryArticle";
+import { checkVars } from '../../utils/vars';
+import { expectPreview } from '../../utils/composer/expectPreview';
+import { inATemporaryArticle } from '../../utils/composer/inATemporaryArticle';
 
 describe('Composer Noting Tests', () => {
   beforeEach(() => {
     checkVars();
-    fetchAndSetCookie(true)
+    fetchAndSetCookie(true);
   });
 
-  inATemporaryArticle('Check that correct flags are present in preview',
+  inATemporaryArticle(
+    'Check that correct flags are present in preview',
     function (id) {
       return cy
-        .get(".ProseMirror").type(`${id} is a `)
-        .get('button[title*="Correct (F7)"]').click()
+        .get('.ProseMirror')
+        .type(`${id} is a `)
+        .get('button[title*="Correct (F7)"]')
+        .click()
         .wait(1000)
-        .get(".ProseMirror").type("test article")
+        .get('.ProseMirror')
+        .type('test article')
         .wait(1000);
     },
     function (id) {
-      return cy
-          .then(async () => expectPreview(
-            id,
-            new RegExp(
+      return cy.then(async () =>
+        expectPreview(
+          id,
+          new RegExp(
             `<p>${id} is a <gu-correct class=".*" title="Correct: .*" data-gu-mark="true" data-note-edited-by=".*" data-note-edited-date=".*" data-type="correct" data-note-id=".*">test article<\/gu-correct><\/p>`
-            )
-          ));
+          )
+        )
+      );
     }
   );
-
 });

--- a/cypress/integration/composer/useFlag.ts
+++ b/cypress/integration/composer/useFlag.ts
@@ -1,32 +1,36 @@
 import { fetchAndSetCookie } from '../../utils/networking';
-import { checkVars } from "../../utils/vars";
-import { expectPreview } from "../../utils/composer/expectPreview";
-import { inATemporaryArticle } from "../../utils/composer/inATemporaryArticle";
+import { checkVars } from '../../utils/vars';
+import { expectPreview } from '../../utils/composer/expectPreview';
+import { inATemporaryArticle } from '../../utils/composer/inATemporaryArticle';
 
 describe('Composer Noting Tests', () => {
   beforeEach(() => {
     checkVars();
-    fetchAndSetCookie(true)
+    fetchAndSetCookie(true);
   });
 
-  inATemporaryArticle('Check that flag marks are present in preview',
+  inATemporaryArticle(
+    'Check that flag marks are present in preview',
     function (id) {
       return cy
-        .get(".ProseMirror").type(`${id} is a `)
-        .get('button[title*="Toggle Flag (F6)"]').click()
+        .get('.ProseMirror')
+        .type(`${id} is a `)
+        .get('button[title*="Toggle Flag (F6)"]')
+        .click()
         .wait(1000)
-        .get(".ProseMirror").type("test article")
+        .get('.ProseMirror')
+        .type('test article')
         .wait(1000);
     },
     function (id) {
-      return cy
-          .then(async () => expectPreview(
-            id,
-            new RegExp(
+      return cy.then(async () =>
+        expectPreview(
+          id,
+          new RegExp(
             `<p>${id} is a <gu-flag class=".*" title="Flag: .*" data-gu-mark="true" data-note-edited-by=".*" data-note-edited-date=".*" data-type="flag" data-note-id=".*">test article<\/gu-flag><\/p>`
-            )
-          ));
+          )
+        )
+      );
     }
   );
-
 });

--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -26,18 +26,18 @@ function setupAliases() {
 describe('Grid Key User Journeys', function () {
   before(() => {
     checkVars();
-    fetchAndSetCookie();
+    fetchAndSetCookie(false);
     deleteImages(cy, [getImageHash()]);
     resetCollection(cy, rootCollection);
   });
 
   beforeEach(() => {
-    fetchAndSetCookie();
+    fetchAndSetCookie(false);
     setupAliases();
   });
 
   after(() => {
-    fetchAndSetCookie();
+    fetchAndSetCookie(false);
     deleteImages(cy, [getImageHash()]);
     resetCollection(cy, rootCollection);
   });

--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -8,7 +8,7 @@ import * as crops from '../../utils/grid/crop';
 import * as image from '../../utils/grid/image';
 import * as collections from '../../utils/grid/collections';
 import { resetCollection } from '../../utils/grid/collections';
-const config = require('../../../env.json');
+import config from '../../../env.json';
 
 // ID of `cypress/fixtures/GridmonTestImage.png`
 const dragImageID = getImageHash();
@@ -43,7 +43,7 @@ describe('Grid Key User Journeys', function () {
   });
 
   it('Upload image, set rights, set metadata, create crop, delete all crops', function () {
-    const imageUrl = `${getDomain('api')}/images/${dragImageID}`;
+    const imageUrl = `${getDomain({ prefix: 'api' })}/images/${dragImageID}`;
     const crop = {
       width: '900',
       height: '540',
@@ -51,13 +51,15 @@ describe('Grid Key User Journeys', function () {
       yValue: '581',
     };
 
-    const cropsUrl = `${getDomain('cropper')}/crops/${getImageHash()}`;
+    const cropsUrl = `${getDomain({
+      prefix: 'cropper',
+    })}/crops/${getImageHash()}`;
 
     // For some reason, on production infrastructure, Cypress interacts with the browser differently and the crop.xValue gets reduced by 1.
     // This is a bug that should be investigated, but for now it's easier to just make a different assertion
-    const cropID = `${config.isDev ? crop.xValue : crop.xValue - 1}_${
-      crop.yValue
-    }_${crop.width}_${crop.height}`;
+    const cropID = `${
+      config.isDev ? Number(crop.xValue) : Number(crop.xValue) - 1
+    }_${crop.yValue}_${crop.width}_${crop.height}`;
 
     cy.visit(getDomain(), {
       onBeforeLoad(win) {
@@ -116,11 +118,12 @@ describe('Grid Key User Journeys', function () {
       `${getImageURL()}?crop=${cropID}`
     );
 
-    const url = `${getDomain('cropper')}/crops/${getImageHash()}`;
+    const url = `${getDomain({ prefix: 'cropper' })}/crops/${getImageHash()}`;
     cy.request('GET', url).then((res) => {
       const cropsBeforeDelete = res.body.data;
       expect(
-        cropsBeforeDelete.filter((ex) => ex.id === cropID).length,
+        cropsBeforeDelete.filter((ex: { id: string }) => ex.id === cropID)
+          .length,
         'Crop with correct ID'
       ).to.be.greaterThan(0);
     });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,15 +1,15 @@
 const browserify = require('@cypress/browserify-preprocessor');
+const fs = require('fs');
+const { cookie } = require('../../src/utils/cookie');
 
 module.exports = (on) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on('task', {
     async getCookie(stage) {
-      const { cookie } = require('../../src/utils/cookie.js');
       return await cookie(stage, false);
     },
     readFileMaybe(filename) {
-      const fs = require('fs');
       if (fs.existsSync(filename)) {
         return fs.readFileSync(filename);
       }

--- a/cypress/utils/composer/deleteArticle.ts
+++ b/cypress/utils/composer/deleteArticle.ts
@@ -1,6 +1,6 @@
 import { getDomain } from '../networking';
 
-export function deleteArticle(id) {
+export function deleteArticle(id: string) {
   return cy
     .get(`a[href*="/content/${id}"]`)
     .click()

--- a/cypress/utils/composer/getContent.ts
+++ b/cypress/utils/composer/getContent.ts
@@ -1,20 +1,20 @@
 export const https = require('https');
 
-export function getContent(url) {
-    return new Promise(function(resolve, reject) {
-        https.get(url, (resp) => {
-            let data = '';
+export function getContent(url: string) {
+  return new Promise(function (resolve) {
+    https.get(url, (resp: http.IncomingMessage) => {
+      let data = '';
 
-            // A chunk of data has been received, add it.
-            resp.on('data', (chunk) => {data += chunk;});
+      // A chunk of data has been received, add it.
+      resp.on('data', (chunk: string) => {
+        data += chunk;
+      });
 
-            // The whole response has been received. Print out the result.
-            resp.on('end', () => {
-                // console.log(JSON.parse(data).explanation);
-                resolve(data);
-
-            });
-        });
+      // The whole response has been received. Print out the result.
+      resp.on('end', () => {
+        // console.log(JSON.parse(data).explanation);
+        resolve(data);
+      });
     });
+  });
 }
-

--- a/cypress/utils/debug.ts
+++ b/cypress/utils/debug.ts
@@ -1,1 +1,3 @@
-export function debug(message) { cy.exec(`echo "${message}" >> debug.log`); }
+export function debug(message: string) {
+  cy.exec(`echo "${message}" >> debug.log`);
+}

--- a/cypress/utils/grid/api.ts
+++ b/cypress/utils/grid/api.ts
@@ -10,15 +10,18 @@ export function getImageURL() {
   return `${getDomain()}/images/${getImageHash()}`;
 }
 
-export async function deleteImages(cy, images) {
-  images.map((id) => {
-    const url = `${getDomain('api')}/images/${id}`;
+export async function deleteImages(
+  cy: Cypress.cy & EventEmitter,
+  images: string[]
+) {
+  images.map((id: string) => {
+    const url = `${getDomain({ prefix: 'api' })}/images/${id}`;
     cy.request({
       method: 'DELETE',
       url,
       failOnStatusCode: false,
       headers: {
-        Origin: getDomain(null, 'integration-tests'),
+        Origin: getDomain({ app: 'integration-tests' }),
       },
     }).then((response) => {
       if (response.status !== 404 && response.status !== 202) {

--- a/cypress/utils/grid/collections.ts
+++ b/cypress/utils/grid/collections.ts
@@ -1,76 +1,74 @@
 import { getDomain } from '../networking';
 
-module.exports = {
-  createChild(collection, name) {
-    // Click on edit collections button
-    cy.get('[data-cy=edit-collections-button]').click();
+export function createChild(collection: string, name: string) {
+  // Click on edit collections button
+  cy.get('[data-cy=edit-collections-button]').click();
 
-    // Click on button and create new child
-    cy.get(`[data-cy="${collection}-collection"]`)
-      .find('[data-cy=create-new-folder-button]')
-      .click({ force: true });
+  // Click on button and create new child
+  cy.get(`[data-cy="${collection}-collection"]`)
+    .find('[data-cy=create-new-folder-button]')
+    .click({ force: true });
 
-    // Type name of new child
-    cy.get(`[data-cy="${collection}-collection"]`)
-      .parent()
-      .find('[data-cy=collection-child-input]')
-      .type(name);
+  // Type name of new child
+  cy.get(`[data-cy="${collection}-collection"]`)
+    .parent()
+    .find('[data-cy=collection-child-input]')
+    .type(name);
 
-    // Save child
-    cy.get(`[data-cy="${collection}-collection"]`)
-      .parent()
-      .find('[data-cy=save-child-button]')
-      .click({ force: true })
-      .should('not.exist');
+  // Save child
+  cy.get(`[data-cy="${collection}-collection"]`)
+    .parent()
+    .find('[data-cy=save-child-button]')
+    .click({ force: true })
+    .should('not.exist');
 
-    // Stop editing collections
-    cy.get('[data-cy=edit-collections-button]').click();
-  },
+  // Stop editing collections
+  cy.get('[data-cy=edit-collections-button]').click();
+}
 
-  goToChild(collection, child) {
-    // Go to new collection
-    cy.get(`[data-cy="${collection}-collection"] button`).click({
-      force: true,
-    });
-    cy.get(`[data-cy="${collection}-collection"]`)
-      .parent()
-      .contains(child)
-      .click({ force: true });
-  },
+export function goToChild(collection: string, child: string) {
+  // Go to new collection
+  cy.get(`[data-cy="${collection}-collection"] button`).click({
+    force: true,
+  });
+  cy.get(`[data-cy="${collection}-collection"]`)
+    .parent()
+    .contains(child)
+    .click({ force: true });
+}
 
-  deleteChild(collection, child) {
-    // Click on edit collections button
-    cy.get('[data-cy=edit-collections-button]').click();
+export function deleteChild(collection: string, child: string) {
+  // Click on edit collections button
+  cy.get('[data-cy=edit-collections-button]').click();
 
-    // Delete child collection
-    cy.get(`[data-cy="${collection}-collection"]`)
-      .parent()
-      .contains(child)
-      .parent()
-      .contains('delete')
-      .click({ force: true })
-      .click({ force: true }); // confirm delete crop
-  },
+  // Delete child collection
+  cy.get(`[data-cy="${collection}-collection"]`)
+    .parent()
+    .contains(child)
+    .parent()
+    .contains('delete')
+    .click({ force: true })
+    .click({ force: true }); // confirm delete crop
+}
 
-  resetCollection(cy, rootCollection) {
-    const url = `${getDomain(null, 'media-collections')}/collections`;
-    // Delete collection
-    const rootCollectionUrl = `${url}/${encodeURIComponent(rootCollection)}`;
-    cy.request({
-      method: 'DELETE',
-      url: rootCollectionUrl,
-      headers: {
-        Origin: getDomain(null, "integration-tests")
-      },
-    });
-    cy.request({
-      url,
-      method: 'POST',
-      body: JSON.stringify({ data: rootCollection }),
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: getDomain(null, "integration-tests")
-      },
-    });
-  },
-};
+export function resetCollection(cy: Cypress.cy, rootCollection: string) {
+  const url = `${getDomain({ app: 'media-collections' })}/collections`;
+  // Delete collection
+  const rootCollectionUrl = `${url}/${encodeURIComponent(rootCollection)}`;
+  cy.request({
+    method: 'DELETE',
+    url: rootCollectionUrl,
+    headers: {
+      Origin: getDomain({ app: 'integration-tests' }),
+    },
+  });
+  cy.request({
+    url,
+    method: 'POST',
+    body: JSON.stringify({ data: rootCollection }),
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: getDomain({ app: 'integration-tests' }),
+    },
+  });
+}

--- a/cypress/utils/grid/crop.ts
+++ b/cypress/utils/grid/crop.ts
@@ -1,25 +1,29 @@
-module.exports = {
-  createCrop(width, height, xValue, yValue, wait) {
-    // Select freeform crop
-    cy.get('[data-cy=crop-options]').contains('freeform').click();
-    // Edit width
-    cy.get('[data-cy=crop-width-input]').clear().type(width);
-    // Edit height
-    cy.get('[data-cy=crop-height-input]').clear().type(height);
-    // Edit x coordinate
-    cy.get('[data-cy=crop-x-value-input]').clear().type(xValue);
-    // Edit y coordinate
-    cy.get('[data-cy=crop-y-value-input]').clear().type(yValue);
+export function createCrop(
+  width: string,
+  height: string,
+  xValue: string,
+  yValue: string,
+  wait: number
+) {
+  // Select freeform crop
+  cy.get('[data-cy=crop-options]').contains('freeform').click();
+  // Edit width
+  cy.get('[data-cy=crop-width-input]').clear().type(width);
+  // Edit height
+  cy.get('[data-cy=crop-height-input]').clear().type(height);
+  // Edit x coordinate
+  cy.get('[data-cy=crop-x-value-input]').clear().type(xValue);
+  // Edit y coordinate
+  cy.get('[data-cy=crop-y-value-input]').clear().type(yValue);
 
-    cy.get('.button').click().wait(wait);
-  },
+  cy.get('.button').click().wait(wait);
+}
 
-  deleteAllCrops() {
-    // Delete all crops
-    cy.get('[data-cy=delete-all-crops-button]')
-      .click()
-      .click()
-      .get('[data-cy=delete-all-crops-button]')
-      .should('not.exist');
-  },
-};
+export function deleteAllCrops() {
+  // Delete all crops
+  cy.get('[data-cy=delete-all-crops-button]')
+    .click()
+    .click()
+    .get('[data-cy=delete-all-crops-button]')
+    .should('not.exist');
+}

--- a/cypress/utils/grid/image.ts
+++ b/cypress/utils/grid/image.ts
@@ -1,68 +1,66 @@
-module.exports = {
-  editRights(rightsType, usage) {
-    cy.get('[data-cy=it-edit-usage-rights-button]').click({ force: true });
-    cy.get('[data-cy=it-rights-select]').select(rightsType);
-    cy.get('[data-cy=it-edit-usage-input]').type(usage);
-    cy.get('.ure__bar > .button-save')
-      .click({ timeout: 5000 }) // Why do we need to wait?
-      .should('not.exist');
-  },
+export function editRights(rightsType: string, usage: string) {
+  cy.get('[data-cy=it-edit-usage-rights-button]').click({ force: true });
+  cy.get('[data-cy=it-rights-select]').select(rightsType);
+  cy.get('[data-cy=it-edit-usage-input]').type(usage);
+  cy.get('.ure__bar > .button-save')
+    .click({ timeout: 5000 }) // Why do we need to wait?
+    .should('not.exist');
+}
 
-  editDescription(description) {
-    cy.get('[data-cy=it-edit-description-button]').click({ force: true });
-    cy.get('[data-cy=metadata-description] .editable-has-buttons')
-      .clear()
-      .type(description);
-    cy.get('[data-cy=metadata-description] .editable-buttons > .button-save')
-      .click()
-      .should('not.exist');
-  },
+export function editDescription(description: string) {
+  cy.get('[data-cy=it-edit-description-button]').click({ force: true });
+  cy.get('[data-cy=metadata-description] .editable-has-buttons')
+    .clear()
+    .type(description);
+  cy.get('[data-cy=metadata-description] .editable-buttons > .button-save')
+    .click()
+    .should('not.exist');
+}
 
-  editByline(byline) {
-    cy.get('[data-cy=it-edit-byline-button]').click({ force: true });
-    cy.get('[data-cy=metadata-byline] .editable-has-buttons')
-      .clear()
-      .type(byline);
-    cy.get('[data-cy=metadata-byline] .editable-buttons > .button-save')
-      .click()
-      .should('not.exist');
-  },
+export function editByline(byline: string) {
+  cy.get('[data-cy=it-edit-byline-button]').click({ force: true });
+  cy.get('[data-cy=metadata-byline] .editable-has-buttons')
+    .clear()
+    .type(byline);
+  cy.get('[data-cy=metadata-byline] .editable-buttons > .button-save')
+    .click()
+    .should('not.exist');
+}
 
-  editCredit(credit) {
-    cy.get('[data-cy=it-edit-credit-button]').click({ force: true });
-    cy.get('[data-cy=metadata-credit] .editable-has-buttons')
-      .clear()
-      .type(credit);
-    cy.get('[data-cy=metadata-credit] .editable-buttons > .button-save')
-      .click()
-      .should('not.exist');
-  },
+export function editCredit(credit: string) {
+  cy.get('[data-cy=it-edit-credit-button]').click({ force: true });
+  cy.get('[data-cy=metadata-credit] .editable-has-buttons')
+    .clear()
+    .type(credit);
+  cy.get('[data-cy=metadata-credit] .editable-buttons > .button-save')
+    .click()
+    .should('not.exist');
+}
 
-  editCopyright(copyright) {
-    cy.get('[data-cy=it-edit-copyright-button]').click({ force: true });
-    cy.get('[data-cy=metadata-copyright] .editable-has-buttons')
-      .clear()
-      .type(copyright);
-    cy.get('[data-cy=metadata-copyright] .editable-buttons > .button-save')
-      .click()
-      .should('not.exist');
-  },
+export function editCopyright(copyright: string) {
+  cy.get('[data-cy=it-edit-copyright-button]').click({ force: true });
+  cy.get('[data-cy=metadata-copyright] .editable-has-buttons')
+    .clear()
+    .type(copyright);
+  cy.get('[data-cy=metadata-copyright] .editable-buttons > .button-save')
+    .click()
+    .should('not.exist');
+}
 
-  addLabel(name) {
-    cy.get('[data-cy=it-add-label-button]').click();
-    cy.get('.text-input').clear().type(name);
-    cy.get('.gr-add-label__form__buttons__button-save')
-      .click()
-      .should('not.exist');
-    cy.get('.labeller').contains(name, { timeout: 10000 }).should('exist');
-  },
+export function addLabel(name: string) {
+  cy.get('[data-cy=it-add-label-button]').click();
+  cy.get('.text-input').clear().type(name);
+  cy.get('.gr-add-label__form__buttons__button-save')
+    .click()
+    .should('not.exist');
+  cy.get('.labeller').contains(name, { timeout: 10000 }).should('exist');
+}
 
-  removeLabel(date) {
-    cy.get('.labeller')
-      .contains(date)
-      .parent()
-      .find('[data-cy=it-remove-label-button]')
-      .click()
-      .should('not.exist');
-  },
-};
+export function removeLabel(date: string) {
+  cy.get('.labeller')
+    .contains(date)
+    .parent()
+    .find('[data-cy=it-remove-label-button]')
+    .click()
+    .should('not.exist');
+}

--- a/cypress/utils/grid/upload.ts
+++ b/cypress/utils/grid/upload.ts
@@ -1,36 +1,34 @@
-module.exports = {
-  setRights(rightsType, usage) {
-    cy.get('ui-upload-jobs [data-cy=edit-rights-button]')
-      .click({ force: true })
-      .get('ui-upload-jobs [data-cy=it-rights-select]')
-      .select(rightsType)
-      .get('ui-upload-jobs [data-cy=it-edit-usage-input]')
-      .type(usage)
-      .get('ui-upload-jobs [data-cy=save-usage-rights]')
-      .click()
-      .should('not.exist');
-  },
+export function setRights(rightsType: string, usage: string) {
+  cy.get('ui-upload-jobs [data-cy=edit-rights-button]')
+    .click({ force: true })
+    .get('ui-upload-jobs [data-cy=it-rights-select]')
+    .select(rightsType)
+    .get('ui-upload-jobs [data-cy=it-edit-usage-input]')
+    .type(usage)
+    .get('ui-upload-jobs [data-cy=save-usage-rights]')
+    .click()
+    .should('not.exist');
+}
 
-  addLabel(name) {
-    cy.get('ui-upload-jobs [data-cy=it-add-label-button]')
-      .click()
-      .get('ui-upload-jobs [data-cy=label-input]')
-      .type(name)
-      .get('ui-upload-jobs [data-cy=save-new-label-button]')
-      .click()
-      .should('not.exist');
-  },
+export function addLabel(name: string) {
+  cy.get('ui-upload-jobs [data-cy=it-add-label-button]')
+    .click()
+    .get('ui-upload-jobs [data-cy=label-input]')
+    .type(name)
+    .get('ui-upload-jobs [data-cy=save-new-label-button]')
+    .click()
+    .should('not.exist');
+}
 
-  addCredit(name) {
-    cy.get('ui-upload-jobs [data-cy=image-metadata-credit]').clear().type(name);
-  },
+export function addCredit(name: string) {
+  cy.get('ui-upload-jobs [data-cy=image-metadata-credit]').clear().type(name);
+}
 
-  addImageToCollection(collection) {
-    cy.get('ui-upload-jobs [data-cy=add-image-to-collection-button]').click();
-    cy.get('.collection-overlay__collections')
-      .find(`[data-cy="${collection}-collection"]`)
-      .contains(`${collection}`)
-      .click({ force: true })
-      .should('not.exist');
-  },
-};
+export function addImageToCollection(collection) {
+  cy.get('ui-upload-jobs [data-cy=add-image-to-collection-button]').click();
+  cy.get('.collection-overlay__collections')
+    .find(`[data-cy="${collection}-collection"]`)
+    .contains(`${collection}`)
+    .click({ force: true })
+    .should('not.exist');
+}

--- a/cypress/utils/networking.ts
+++ b/cypress/utils/networking.ts
@@ -1,16 +1,31 @@
-const { baseUrls } = require('../../cypress.env.json');
+import { baseUrls } from '../../cypress.env.json';
 
-export function getDomain(prefix, overrideApp) {
-  const stage = Cypress.env('STAGE').toLowerCase();
-  const app = overrideApp || Cypress.env('APP');
+interface Cookie {
+  cookie: string;
+  domain: string;
+}
+
+interface GetDomainOptions {
+  app?: string;
+  prefix?: string;
+  stage?: string;
+}
+
+export function getDomain(options?: GetDomainOptions) {
+  const stage = options?.stage || Cypress.env('STAGE').toLowerCase();
+  const app = options?.app || Cypress.env('APP');
   const appName = baseUrls[app] || app;
-  const subdomain = prefix ? prefix + '.' + appName : appName;
+  const subdomain = options?.prefix ? options.prefix + '.' + appName : appName;
   return stage.toLowerCase() === 'prod'
     ? `https://${subdomain}.gutools.co.uk`
     : `https://${subdomain}.${stage}.dev-gutools.co.uk`;
 }
 
-export function setCookie(cy, cookie, visitDomain = true) {
+export function setCookie(
+  cy: Cypress.cy & EventEmitter,
+  cookie: Cookie,
+  visitDomain = true
+) {
   cy.setCookie('gutoolsAuth-assym', cookie.cookie, {
     domain: `.${cookie.domain}`,
     path: '/',
@@ -24,10 +39,10 @@ export function setCookie(cy, cookie, visitDomain = true) {
   }
 }
 
-export function fetchAndSetCookie(visitDomain) {
+export function fetchAndSetCookie(visitDomain = true) {
   return cy.task('getCookie', Cypress.env('STAGE')).then((cookie) => {
     expect(cookie).to.have.property('cookie');
     expect(cookie).to.have.property('domain');
-    return setCookie(cy, cookie, visitDomain);
+    return setCookie(cy, (cookie as unknown) as Cookie, visitDomain);
   });
 }

--- a/cypress/utils/wait.ts
+++ b/cypress/utils/wait.ts
@@ -1,1 +1,3 @@
-export function wait(seconds) { return cy.wait(seconds * 1000); }
+export function wait(seconds: number) {
+  return cy.wait(seconds * 1000);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1370,6 +1370,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
     "@types/jquery": {
       "version": "3.3.31",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
@@ -1378,6 +1384,12 @@
       "requires": {
         "@types/sizzle": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.149",
@@ -1455,6 +1467,93 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.0.tgz",
+      "integrity": "sha512-ubHlHVt1lsPQB/CZdEov9XuOFhNG9YRC//kuiS1cMQI6Bs1SsqKrEmZnpgRwthGR09/kEDtr9MywlqXyyYd8GA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "3.6.0",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.6.0.tgz",
+      "integrity": "sha512-4Vdf2hvYMUnTdkCNZu+yYlFtL2v+N2R7JOynIOkFbPjf9o9wQvRwRkzUdWlFd2YiiUwJLbuuLnl5civNg5ykOQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/types": "3.6.0",
+        "@typescript-eslint/typescript-estree": "3.6.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.6.0.tgz",
+      "integrity": "sha512-taghDxuLhbDAD1U5Fk8vF+MnR0yiFE9Z3v2/bYScFb0N1I9SK8eKHkdJl1DAD48OGFDMFTeOTX0z7g0W6SYUXw==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "3.6.0",
+        "@typescript-eslint/types": "3.6.0",
+        "@typescript-eslint/typescript-estree": "3.6.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-JwVj74ohUSt0ZPG+LZ7hb95fW8DFOqBuR6gE7qzq55KDI3BepqsCtHfBIoa0+Xi1AI7fq5nCu2VQL8z4eYftqg==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.6.0.tgz",
+      "integrity": "sha512-G57NDSABHjvob7zVV09ehWyD1K6/YUKjz5+AufObFyjNO4DVmKejj47MHjVHHlZZKgmpJD2yyH9lfCXHrPITFg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "3.6.0",
+        "@typescript-eslint/visitor-keys": "3.6.0",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.6.0.tgz",
+      "integrity": "sha512-p1izllL2Ubwunite0ITjubuMQRBGgjdVYwyG7lXPX8GbrA6qF0uwSRz9MnXZaHMxID4948gX0Ez8v9tUDi/KfQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "JSONStream": {
@@ -2636,9 +2735,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
     },
     "cliui": {
@@ -3440,6 +3539,21 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3456,9 +3570,9 @@
           }
         },
         "strip-json-comments": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
       }
@@ -3479,9 +3593,9 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -3489,18 +3603,18 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
@@ -4357,21 +4471,21 @@
       }
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.1.tgz",
+      "integrity": "sha512-/+vOpHQHhoh90Znev8BXiuw1TDQ7IDxWsQnFafUEoK5+4uN5Eoz1p+3GqOj/NtzEi9VzWKQcV9Bm+i8moxedsA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
+        "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.16",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
+        "rxjs": "^6.6.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -4403,9 +4517,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -4457,6 +4571,12 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        },
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -4480,6 +4600,15 @@
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
+          }
+        },
+        "rxjs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+          "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "string-width": {
@@ -6315,9 +6444,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
     "regexpu-core": {
@@ -7220,6 +7349,15 @@
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
@@ -7459,9 +7597,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "verror": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,9 +1398,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
+      "version": "14.0.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.22.tgz",
+      "integrity": "sha512-emeGcJvdiZ4Z3ohbmw93E/64jRzUHAItSHt8nF7M4TGgQTiWqFVGB8KNpLGFmUHmHLvjvBgFwVlqNcq+VuGv9g==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,12 +1470,12 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.0.tgz",
-      "integrity": "sha512-ubHlHVt1lsPQB/CZdEov9XuOFhNG9YRC//kuiS1cMQI6Bs1SsqKrEmZnpgRwthGR09/kEDtr9MywlqXyyYd8GA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.1.tgz",
+      "integrity": "sha512-06lfjo76naNeOMDl+mWG9Fh/a0UHKLGhin+mGaIw72FUMbMGBkdi/FEJmgEDzh4eE73KIYzHWvOCYJ0ak7nrJQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.6.0",
+        "@typescript-eslint/experimental-utils": "3.6.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1483,6 +1483,50 @@
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.6.1.tgz",
+          "integrity": "sha512-oS+hihzQE5M84ewXrTlVx7eTgc52eu+sVmG7ayLfOhyZmJ8Unvf3osyFQNADHP26yoThFfbxcibbO0d2FjnYhg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/types": "3.6.1",
+            "@typescript-eslint/typescript-estree": "3.6.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-NPxd5yXG63gx57WDTW1rp0cF3XlNuuFFB5G+Kc48zZ+51ZnQn9yjDEsjTPQ+aWM+V+Z0I4kuTFKjKvgcT1F7xQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.6.1.tgz",
+          "integrity": "sha512-G4XRe/ZbCZkL1fy09DPN3U0mR6SayIv1zSeBNquRFRk7CnVLgkC2ZPj8llEMJg5Y8dJ3T76SvTGtceytniaztQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "3.6.1",
+            "@typescript-eslint/visitor-keys": "3.6.1",
+            "debug": "^4.1.1",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.6.1.tgz",
+          "integrity": "sha512-qC8Olwz5ZyMTZrh4Wl3K4U6tfms0R/mzU4/5W3XeUZptVraGVmbptJbn6h2Ey6Rb3hOs3zWoAUebZk8t47KGiQ==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@guardian/pan-domain-node": "^0.4.2",
     "@types/node": "^14.0.22",
     "@types/node-fetch": "^2.5.6",
+    "@typescript-eslint/eslint-plugin": "^3.6.0",
+    "@typescript-eslint/parser": "^3.6.0",
     "cypress": "^4.3.0",
     "cypress-file-upload": "^4.0.7",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@guardian/pan-domain-node": "^0.4.2",
     "@types/node": "^14.0.22",
     "@types/node-fetch": "^2.5.6",
-    "@typescript-eslint/eslint-plugin": "^3.6.0",
+    "@typescript-eslint/eslint-plugin": "^3.6.1",
     "@typescript-eslint/parser": "^3.6.0",
     "cypress": "^4.3.0",
     "cypress-file-upload": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@cypress/browserify-preprocessor": "^3.0.0",
     "@guardian/node-riffraff-artifact": "^0.1.8",
     "@guardian/pan-domain-node": "^0.4.2",
+    "@types/node": "^14.0.22",
     "@types/node-fetch": "^2.5.6",
     "cypress": "^4.3.0",
     "cypress-file-upload": "^4.0.7",

--- a/reporters/pagerduty.js
+++ b/reporters/pagerduty.js
@@ -1,10 +1,10 @@
-const mocha = require('mocha');
-const fs = require('fs');
-const path = require('path');
-const fetch = require('node-fetch');
+import mocha from 'mocha';
+import fs from 'fs';
+import path from 'path';
+import fetch from 'node-fetch';
 
-const { Logger } = require('../src/utils/logger');
-const env = require('../env.json');
+import { Logger } from '../src/utils/logger';
+import env from '../env.json';
 
 const logDir = path.join(__dirname, '../logs');
 const logFile = 'tests.json.log';
@@ -83,7 +83,7 @@ function Pagerduty(runner) {
     await callPagerduty(test, 'trigger', {
       error: err.message,
       videosFolder: `https://s3.console.aws.amazon.com/s3/buckets/${env.videoBucket}/videos/${year}/${month}/${date}/?region=${region}&tab=overview`,
-      videosAccount: env.aws.profile
+      videosAccount: env.aws.profile,
     });
   });
 

--- a/reporters/pagerduty.js
+++ b/reporters/pagerduty.js
@@ -1,10 +1,10 @@
-import mocha from 'mocha';
-import fs from 'fs';
-import path from 'path';
-import fetch from 'node-fetch';
+const mocha = require('mocha');
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
 
-import { Logger } from '../src/utils/logger';
-import env from '../env.json';
+const { Logger } = require('../src/utils/logger');
+const env = require('../env.json');
 
 const logDir = path.join(__dirname, '../logs');
 const logFile = 'tests.json.log';

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -1,9 +1,9 @@
-import AWS from 'aws-sdk';
-import path from 'path';
-import fs from 'fs';
-import { Logger } from '../src/utils/logger';
-import { uploadVideoToS3 } from '../src/utils/s3';
-import config from '../env.json';
+const AWS = require('aws-sdk');
+const path = require('path');
+const fs = require('fs');
+const { Logger } = require('../src/utils/logger');
+const { uploadVideoToS3 } = require('../src/utils/s3');
+const config = require('../env.json');
 
 const suite = process.env.SUITE;
 

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -1,10 +1,9 @@
-const AWS = require('aws-sdk');
-const path = require('path');
-const fs = require('fs');
-const { Logger } = require('../src/utils/logger');
-
-const { uploadVideoToS3 } = require('../src/utils/s3');
-const config = require('../env.json');
+import AWS from 'aws-sdk';
+import path from 'path';
+import fs from 'fs';
+import { Logger } from '../src/utils/logger';
+import { uploadVideoToS3 } from '../src/utils/s3';
+import config from '../env.json';
 
 const suite = process.env.SUITE;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,16 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
     "strict": true,
     "baseUrl": "../node_modules",
     "target": "es5",
-    "lib": ["es5", "dom"],
+    "lib": [
+      "es5",
+      "dom",
+      "ES2015.Promise"
+    ],
     "types": ["cypress"]
   },
   "include": ["**/*.ts"]


### PR DESCRIPTION
## What does this change?

Following [this PR](https://github.com/guardian/editorial-tools-integration-tests/pull/39), this repository now uses Typescript for the integration tests. Now that we can use Typescript files, this PR updates the files to make use of all the goodness Typescript has to offer. It makes the following refactors:

* Converts `.js` files to `.ts` (sorry that this makes the diff horrible, as it just shows a delete/add as opposed to a change)
* Adds type annotations to functions
* Swaps `const foo = require('bar')` syntax for `import foo from 'bar'`
* Configures eslint/tsconfig/prettier to work best in the repo.

This diff is really gross, but it's only a combination of moving JS -> TS, making the above changes and prettifying the files. I've run the tests against all non-local environments (including the `scripts/run.sh` test run in production) and they all pass.

## How can we measure success?

The tests continue to pass as normal!

## Do the relevant integration tests still pass?

Yes!

[X] Tested against Grid TEST & PROD, Composer CODE & PROD 

## Images
