### PR TITLE
Remove conditional assertion, delete usages & crops

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -18,7 +18,7 @@ import { stopEditingAndClose } from '../../utils/composer/stopEditingAndClose';
 // ID of `cypress/fixtures/GridmonTestImage.png`
 const dragImageID = getImageHash();
 const rootCollection = 'Cypress Integration Testing';
-const date = new Date().toString();
+const date = Date.now().toString();
 const waits = { createCrop: 1000 };
 
 function setupAliases() {
@@ -60,11 +60,7 @@ describe('Grid Key User Journeys', function () {
       prefix: 'cropper',
     })}/crops/${getImageHash()}`;
 
-    // For some reason, on production infrastructure, Cypress interacts with the browser differently and the crop.xValue gets reduced by 1.
-    // This is a bug that should be investigated, but for now it's easier to just make a different assertion
-    const cropID = `${
-      config.isDev ? Number(crop.xValue) : Number(crop.xValue) - 1
-    }_${crop.yValue}_${crop.width}_${crop.height}`;
+    const cropID = `${crop.xValue}_${crop.yValue}_${crop.width}_${crop.height}`;
 
     cy.visit(getDomain(), {
       onBeforeLoad(win) {

--- a/cypress/utils/grid/api.ts
+++ b/cypress/utils/grid/api.ts
@@ -15,6 +15,28 @@ export async function deleteImages(
   images: string[]
 ) {
   images.map((id: string) => {
+    const cropper = `${getDomain({
+      prefix: 'cropper',
+    })}/crops/${id}`;
+    cy.request({
+      method: 'DELETE',
+      url: cropper,
+      headers: {
+        Origin: getDomain({ app: 'integration-tests' }),
+      },
+    });
+
+    const usages = `${getDomain({
+      app: 'media-usage',
+    })}/usages/media/${id}`;
+    cy.request({
+      method: 'DELETE',
+      url: usages,
+      headers: {
+        Origin: getDomain({ app: 'integration-tests' }),
+      },
+    });
+
     const url = `${getDomain({ prefix: 'api' })}/images/${id}`;
     cy.request({
       method: 'DELETE',


### PR DESCRIPTION
## What does this change?

Previously, some tests were responsible for cleaning up after themselves, and so it could leave behind artefacts (like a crop) if it failed half-way through. This would then cause issues in cleanup tasks where we tried deleting the image and received `405 Method Not Allowed` errors as there were remaining crops and usages for the image.

This PR deletes all crops and usages from the image before deleting it itself, so we always have a clean slate at the start of a test run.

## How can we measure success?

The tests start passing again.

## Do the relevant integration tests still pass?

[X] Tested against Grid PROD

## Images
