### PR TITLE
Increase rights button save timeout

### DIFF
--- a/cypress/utils/grid/image.ts
+++ b/cypress/utils/grid/image.ts
@@ -1,9 +1,11 @@
+import config from '../../../cypress.json';
+
 export function editRights(rightsType: string, usage: string) {
   cy.get('[data-cy=it-edit-usage-rights-button]').click({ force: true });
   cy.get('[data-cy=it-rights-select]').select(rightsType);
   cy.get('[data-cy=it-edit-usage-input]').type(usage);
   cy.get('.ure__bar > .button-save')
-    .click({ timeout: 10000 }) // Why do we need to wait?
+    .click({ timeout: config.defaultCommandTimeout }) // Why do we need to wait?
     .should('not.exist');
 }
 

--- a/cypress/utils/grid/image.ts
+++ b/cypress/utils/grid/image.ts
@@ -3,7 +3,7 @@ export function editRights(rightsType: string, usage: string) {
   cy.get('[data-cy=it-rights-select]').select(rightsType);
   cy.get('[data-cy=it-edit-usage-input]').type(usage);
   cy.get('.ure__bar > .button-save')
-    .click({ timeout: 5000 }) // Why do we need to wait?
+    .click({ timeout: 10000 }) // Why do we need to wait?
     .should('not.exist');
 }
 


### PR DESCRIPTION
## What does this change?

Whereas we globally set the action timeout to 10 seconds in `cypress.json`, it looks like this action was manually set to 5 seconds. The affected test appears to flake due to this being too tight, so this PR increases the timeout to the global 1000.

## How can we measure success?

The test according to the global timeout, rather than a hardcoded one.

## Do the relevant integration tests still pass?

[X] Tested against Grid TEST

## Images
![image](https://user-images.githubusercontent.com/25747336/88295018-cb1d4100-ccf4-11ea-97c2-5835db1786d6.png)

