### PR TITLE
Add Workflow integration test for creation and deletion

### DIFF
--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -26,7 +26,7 @@ describe('Workflow Integration Tests', () => {
     cy.get('[wf-dropdown-toggle]').contains('Create new').click();
     cy.get('#testing-dashboard-create-dropdown-Article').click();
     cy.get('#stub_title').type(articleTitle);
-    cy.get('#stub_section').select('UK News');
+    cy.get('#stub_section').select('Training');
     cy.get('#testing-create-in-composer').click();
     cy.get('.modal-dialog')
       .contains('Completed successfully!')

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -1,13 +1,44 @@
 import { checkVars } from '../../utils/vars';
 import { fetchAndSetCookie, getDomain } from '../../utils/networking';
+import { deleteAllArticles } from '../../utils/composer/api';
+import { createAndEditArticle } from '../../utils/composer/createArticle';
+import { getId } from '../../utils/composer/getId';
+import { startEditing } from '../../utils/composer/startEditing';
+import { stopEditingAndClose } from '../../utils/composer/stopEditingAndClose';
+import { deleteArticle } from '../../utils/composer/deleteArticle';
 
 describe('Workflow Integration Tests', () => {
   beforeEach(() => {
     checkVars();
     fetchAndSetCookie({ visitDomain: false });
   });
-  it('should hit the landing', function () {
+
+  after(() => {
+    fetchAndSetCookie({ visitDomain: false });
+    deleteAllArticles();
+  });
+
+  it('Create an article from within Workflow', function () {
     cy.visit(getDomain());
+
+    // Create article
+    cy.get('[wf-dropdown-toggle]')
+      .contains('Create new')
+      .click()
+      .get('#testing-dashboard-create-dropdown-Article')
+      .click()
+      .get('#stub_title')
+      .type(`Cypress Integration Testing Article ${Date.now()}`)
+      .get('#testing-create-in-composer')
+      .click();
+  });
+
+  xit('Delete an article from within Workflow', function () {
+    cy.visit(getDomain({ app: 'composer' }));
+    createAndEditArticle();
+    cy.url().then((url) => {
+      const id = getId(url, { app: 'composer' });
+    });
     cy.pause();
   });
 });

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -1,11 +1,6 @@
 import { checkVars } from '../../utils/vars';
 import { fetchAndSetCookie, getDomain } from '../../utils/networking';
 import { deleteAllArticles } from '../../utils/composer/api';
-import { createAndEditArticle } from '../../utils/composer/createArticle';
-import { getId } from '../../utils/composer/getId';
-import { startEditing } from '../../utils/composer/startEditing';
-import { stopEditingAndClose } from '../../utils/composer/stopEditingAndClose';
-import { deleteArticle } from '../../utils/composer/deleteArticle';
 
 describe('Workflow Integration Tests', () => {
   beforeEach(() => {
@@ -28,15 +23,14 @@ describe('Workflow Integration Tests', () => {
     cy.visit(getDomain());
 
     // Create article
-    cy.get('[wf-dropdown-toggle]')
-      .contains('Create new')
-      .click()
-      .get('#testing-dashboard-create-dropdown-Article')
-      .click()
-      .get('#stub_title')
-      .type(articleTitle)
-      .get('#testing-create-in-composer')
-      .click()
+    cy.get('[wf-dropdown-toggle]').contains('Create new').click();
+    cy.get('#testing-dashboard-create-dropdown-Article').click();
+    cy.get('#stub_title').type(articleTitle);
+    cy.get('#stub_section').select('UK News');
+    cy.get('#testing-create-in-composer').click();
+    cy.get('.modal-dialog')
+      .contains('Completed successfully!')
+      .should('exist')
       .get('.close')
       .click();
 

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -1,0 +1,13 @@
+import { checkVars } from '../../utils/vars';
+import { fetchAndSetCookie, getDomain } from '../../utils/networking';
+
+describe('Workflow Integration Tests', () => {
+  beforeEach(() => {
+    checkVars();
+    fetchAndSetCookie({ visitDomain: false });
+  });
+  it('should hit the landing', function () {
+    cy.visit(getDomain());
+    cy.pause();
+  });
+});

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -19,6 +19,12 @@ describe('Workflow Integration Tests', () => {
   });
 
   it('Create an article from within Workflow', function () {
+    const articleTitle = `Cypress Integration Testing Article ${Date.now()}`;
+    cy.server();
+    cy.route(`/api/content?text=${articleTitle.split(' ').join('+')}`).as(
+      'searchForArticle'
+    );
+
     cy.visit(getDomain());
 
     // Create article
@@ -28,17 +34,24 @@ describe('Workflow Integration Tests', () => {
       .get('#testing-dashboard-create-dropdown-Article')
       .click()
       .get('#stub_title')
-      .type(`Cypress Integration Testing Article ${Date.now()}`)
+      .type(articleTitle)
       .get('#testing-create-in-composer')
+      .click()
+      .get('.close')
       .click();
-  });
 
-  xit('Delete an article from within Workflow', function () {
-    cy.visit(getDomain({ app: 'composer' }));
-    createAndEditArticle();
-    cy.url().then((url) => {
-      const id = getId(url, { app: 'composer' });
-    });
-    cy.pause();
+    // Search for it in Workflow
+    cy.get('#testing-dashboard-toolbar-section-search').type(
+      articleTitle + '{enter}'
+    );
+
+    // Delete from within Workflow
+    cy.wait('@searchForArticle')
+      .get('#testing-content-list-item-title-anchor-text')
+      .contains(articleTitle)
+      .parent()
+      .click();
+
+    cy.get('.drawer__toolbar-item--danger').click();
   });
 });

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -1,14 +1,12 @@
 import { getDomain } from '../networking';
 import env from '../../../env.json';
 
-interface ContentResponse {
-  data: Content;
-}
-
 interface Content {
-  published: boolean;
-  id: string;
-  collaborators: [];
+  data: {
+    published: boolean;
+    id: string;
+    collaborators: [];
+  };
 }
 
 export const deleteAllArticles = () => {
@@ -20,13 +18,13 @@ export const deleteAllArticles = () => {
     headers: {
       Origin: getDomain({ app: 'integration-tests' }),
     },
-  }).then(({ body: { data: data } }: { body: { data: ContentResponse[] } }) => {
-    const deletable = data.filter(
+  }).then(({ body: { data: contents } }: { body: { data: Content[] } }) => {
+    const deletable = contents.filter(
       ({ data }) => !data.published && data.collaborators.length < 2
     );
 
     cy.log(
-      `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
+      `${contents.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
     );
 
     deletable.forEach(({ data }) => {

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -21,9 +21,9 @@ export const deleteAllArticles = () => {
       Origin: getDomain({ app: 'integration-tests' }),
     },
   }).then(({ body: { data: data } }: { body: { data: ContentResponse[] } }) => {
-    const deletable: Partial<Content>[] = data
-      .filter(({ data }) => !data.published && data.collaborators.length < 2)
-      .map(({ data }) => ({ id: data.id, collaborators: data.collaborators }));
+    const deletable = data.filter(
+      ({ data }) => !data.published && data.collaborators.length < 2
+    );
 
     cy.log(
       `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -6,6 +6,17 @@ interface Content {
     published: boolean;
     id: string;
     collaborators: [];
+    contentChangeDetails: {
+      data: {
+        created: {
+          user: {
+            email: string;
+            firstName: string;
+            lastName: string;
+          };
+        };
+      };
+    };
   };
 }
 
@@ -20,7 +31,10 @@ export const deleteAllArticles = () => {
     },
   }).then(({ body: { data: contents } }: { body: { data: Content[] } }) => {
     const deletable = contents.filter(
-      ({ data }) => !data.published && data.collaborators.length < 2
+      ({ data }) =>
+        !data.published &&
+        data.collaborators.length < 2 &&
+        data.contentChangeDetails.data.created.user.email === env.user.email
     );
 
     cy.log(

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -29,9 +29,9 @@ export const deleteAllArticles = () => {
       `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
     );
 
-    deletable.forEach((article) => {
+    deletable.forEach(({ data }) => {
       cy.request({
-        url: `${apiBaseUrl}/content/${article.id}`,
+        url: `${apiBaseUrl}/content/${data.id}`,
         method: 'DELETE',
         headers: {
           Origin: getDomain({ app: 'integration-tests' }),

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -10,7 +10,7 @@ interface Content {
 }
 
 export const deleteAllArticles = () => {
-  const apiBaseUrl = `${getDomain()}/api`;
+  const apiBaseUrl = `${getDomain({ app: 'composer' })}/api`;
 
   cy.request({
     url: `${apiBaseUrl}/content?collaboratorEmail=${env.user.email}`,


### PR DESCRIPTION
## What does this change?

To be merged after: https://github.com/guardian/editorial-tools-integration-tests/pull/49

This PR adds the first integration test for Workflow. It:

1. Creates an article
2. Searches for it in Workflow UI
3. Deletes it 

## How can we measure success?

The test passes while Workflow is healthy, and only fails when Workflow has issues.

## Do the relevant integration tests still pass?

[X] Tested against Workflow CODE & PROD

## Images
