### PR TITLE
Allow Composer to wait to create article when asserting the new URL

### DIFF
--- a/cypress/utils/composer/getId.ts
+++ b/cypress/utils/composer/getId.ts
@@ -2,6 +2,6 @@ import { getDomain } from '../networking';
 
 export function getId(url: string, options?: { app?: string; stage?: string }) {
   const domain = getDomain(options);
-  expect(url).to.match(new RegExp(`${domain}/content\/`));
+  cy.location('href').should('match', new RegExp(`${domain}/content\/`));
   return url.split('/')[4];
 }


### PR DESCRIPTION
## What does this change?

Currently, the Composer tests can flake because, after creating a new article, Composer hasn't loaded the article itself when asserting expecting the URL to have `/content`. 

By using the `.should()` function, Cypress will wait for the default timeout (found in `~/cypress.json`) for the page to change, rather than immediately assert the URL and potentially act too quickly.

## How can we measure success?

The Composer tests stop flaking due to the test acting too quickly.

## Do the relevant integration tests still pass?

[X] Tested against Composer CODE & PROD

## Images

Before:
![image](https://user-images.githubusercontent.com/25747336/88413680-7bfa0d80-cdd3-11ea-8242-3819dea753ad.png)

After:
![image](https://user-images.githubusercontent.com/25747336/88413733-98964580-cdd3-11ea-9939-c3e197ca1b15.png)
