### PR TITLE
Refresh env file every time setup is called

### DIFF
--- a/scripts/fetch-config.sh
+++ b/scripts/fetch-config.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+STAGE=${1:-LOCAL}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [[ ${STAGE} != "PROD"  ]]; then
+    aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json --profile media-service
+else
+    aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,11 +36,7 @@ checkIfAbleToTalkToAWS() {
 
 fetchEnv() {
     if [[ ! -f ${DIR}/../env.json ]]; then
-        if [[ ${STAGE} != "PROD"  ]]; then
-            aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json --profile media-service
-        else
-            aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json
-        fi
+        "${DIR}/fetch-config.sh" "${STAGE}"
     fi
 }
 


### PR DESCRIPTION
## What does this change?

Currently, running `scripts/setup.sh` only refreshed the `env.json` file when it doesn't exist (eg when the repo is cloned). This means that any changes to the env file would require users to manually delete their local `env.json` then run `setup.sh`, which isn't good.

This removes the check for `env.json` existing as a conditional for updating the file.

## How can we measure success?

`env.json` is fetched every time `scripts/setup.sh` is called.

## Do the relevant integration tests still pass?

[X] Tested against Grid TEST

## Images
