### PR TITLE
Delete all Composer articles for test user after suite runs (again)

### DIFF
--- a/cypress/integration/composer/integration.ts
+++ b/cypress/integration/composer/integration.ts
@@ -2,12 +2,18 @@ import { checkVars } from '../../utils/vars';
 import { fetchAndSetCookie } from '../../utils/networking';
 import { inATemporaryArticle } from '../../utils/composer/inATemporaryArticle';
 import { expectPreview } from '../../utils/composer/expectPreview';
+import { deleteAllArticles } from '../../utils/composer/api';
 
 describe('Composer Integration Tests', () => {
   beforeEach(() => {
     checkVars();
     fetchAndSetCookie({ visitDomain: true });
   });
+
+  after(() => {
+    deleteAllArticles();
+  });
+
   describe('Composer Basic Behaviour Tests', () => {
     inATemporaryArticle('Do nothing but create and delete');
   });

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -1,14 +1,12 @@
 import { getDomain } from '../networking';
 import env from '../../../env.json';
 
-interface ContentResponse {
-  data: Content;
-}
-
 interface Content {
-  published: boolean;
-  id: string;
-  collaborators: [];
+  data: {
+    published: boolean;
+    id: string;
+    collaborators: [];
+  };
 }
 
 export const deleteAllArticles = () => {
@@ -20,13 +18,13 @@ export const deleteAllArticles = () => {
     headers: {
       Origin: getDomain({ app: 'integration-tests' }),
     },
-  }).then(({ body: { data: data } }: { body: { data: ContentResponse[] } }) => {
-    const deletable = data.filter(
+  }).then(({ body: { data: contents } }: { body: { data: Content[] } }) => {
+    const deletable = contents.filter(
       ({ data }) => !data.published && data.collaborators.length < 2
     );
 
     cy.log(
-      `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
+      `${contents.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
     );
 
     deletable.forEach(({ data }) => {

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -21,9 +21,9 @@ export const deleteAllArticles = () => {
       Origin: getDomain({ app: 'integration-tests' }),
     },
   }).then(({ body: { data: data } }: { body: { data: ContentResponse[] } }) => {
-    const deletable: Partial<Content>[] = data
-      .filter(({ data }) => !data.published && data.collaborators.length < 2)
-      .map(({ data }) => ({ id: data.id, collaborators: data.collaborators }));
+    const deletable = data.filter(
+      ({ data }) => !data.published && data.collaborators.length < 2
+    );
 
     cy.log(
       `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -1,0 +1,42 @@
+import { getDomain } from '../networking';
+import env from '../../../env.json';
+
+interface ContentResponse {
+  data: Content;
+}
+
+interface Content {
+  published: boolean;
+  id: string;
+  collaborators: [];
+}
+
+export const deleteAllArticles = () => {
+  const apiBaseUrl = `${getDomain()}/api`;
+
+  cy.request({
+    url: `${apiBaseUrl}/content?collaboratorEmail=${env.user.email}`,
+    method: 'GET',
+    headers: {
+      Origin: getDomain({ app: 'integration-tests' }),
+    },
+  }).then(({ body: { data: data } }: { body: { data: ContentResponse[] } }) => {
+    const deletable: Partial<Content>[] = data
+      .filter(({ data }) => !data.published && data.collaborators.length < 2)
+      .map(({ data }) => ({ id: data.id, collaborators: data.collaborators }));
+
+    cy.log(
+      `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
+    );
+
+    deletable.forEach((article) => {
+      cy.request({
+        url: `${apiBaseUrl}/content/${article.id}`,
+        method: 'DELETE',
+        headers: {
+          Origin: getDomain({ app: 'integration-tests' }),
+        },
+      });
+    });
+  });
+};

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -29,9 +29,9 @@ export const deleteAllArticles = () => {
       `${data.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
     );
 
-    deletable.forEach((article) => {
+    deletable.forEach(({ data }) => {
       cy.request({
-        url: `${apiBaseUrl}/content/${article.id}`,
+        url: `${apiBaseUrl}/content/${data.id}`,
         method: 'DELETE',
         headers: {
           Origin: getDomain({ app: 'integration-tests' }),


### PR DESCRIPTION
## What does this change?

**This is now safe to merge as it uses a new user for the tests so it won't interfere with Prodmon tests** 

Currently, the last thing a Composer integration test does is delete the article it creates within the test. If the test fails, however, that article never gets deleted.

Failing tests in production has resulted in almost 2000 temporary articles being created, which is _noisy_.

This PR adds a `deleteArticles` step, which will query the Composer API for all articles created by the test user (which should only therefore exist for testing purposes), filter for ones that have only 1 (or fewer) contributors (in case a real user is doing something with a test article for some reason) and that haven't been published (as to not interfere with ProdMon).

It will then map over the unpublished and collaborator-less articles and delete them, ensuring no stale articles are leftover.

It would be good to additionally check if an article has someone in it (ie with presence) but I'm not sure how we could do that?

## How can we measure success?

No stale articles are leftover from failing tests.

## Do the relevant integration tests still pass?

[X] Tested against Composer CODE, Grid TEST

## Images
