### PR TITLE
Don't edit rights manually as Grid will trigger it for you

### DIFF
--- a/cypress/utils/grid/upload.ts
+++ b/cypress/utils/grid/upload.ts
@@ -10,9 +10,8 @@ export function ensureImageUploadedCorrectly() {
 }
 
 export function setRights(rightsType: string, usage: string) {
-  cy.get('ui-upload-jobs [data-cy=edit-rights-button]')
-    .click({ force: true })
-    .get('ui-upload-jobs [data-cy=it-rights-select]')
+  cy.get('ui-upload-jobs [data-cy=it-rights-select]')
+    .should('be.visible')
     .select(rightsType)
     .get('ui-upload-jobs [data-cy=it-edit-usage-input]')
     .type(usage)


### PR DESCRIPTION
## What does this change?

When uploading a new image to the Grid, the rights dropdown menu automatically pops up if not set. In our test, we currently click the `+` button to set rights, but since the Grid takes a second to realise no rights have been set and open the dropdown menu, sometimes the test fails as it's trying to select something that doesn't exist.

This PR waits for the dropdown menu instead of forcing it by clicking the button that may not always be there.

## How can we measure success?

The Grid upload test stops failing intermittently due to this.

## Do the relevant integration tests still pass?

[X] Tested against Grid PROD

## Images

![image](https://user-images.githubusercontent.com/25747336/88687748-8a586a00-d0f0-11ea-87b7-9804e102b171.png)


![image](https://user-images.githubusercontent.com/25747336/88687676-7876c700-d0f0-11ea-808b-755ba3583286.png)
