### PR TITLE
Increase global command timeout

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,5 @@
   "viewportWidth": 1280,
   "viewportHeight": 720,
   "videoCompression": false,
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 20000
 }


### PR DESCRIPTION
## What does this change?

Sometimes, for not always clear reasons, the tests fail because an action or check has not completed before the 10-second timeout. 

In the past, discussions were had about increasing the timeout, with the logic that **these tests are to test the ability to complete key user paths, not to complete them in a certain amount of time**. It appears that 10 seconds might be too short a timeout to complete some actions (namely uploading an image to the Grid, where this test failed most recently), so increasing it to 20 seconds (which is a _long_ time) should hopefully allow for slow actions completing whilst still erroring on fully hanging or incomplete actions.

## How can we measure success?

We only see test failures due to hanging or broken processes, rather than ones that are just a bit slow.

## Do the relevant integration tests still pass?

[X] Tested against Grid TEST

## Images

![image](https://user-images.githubusercontent.com/25747336/89779083-8c65f400-db06-11ea-8e74-1cfa88cf849a.png)

