### PR TITLE
Improve Workflow test reliability 

### DIFF
--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -2,6 +2,8 @@ import { checkVars } from '../../utils/vars';
 import { fetchAndSetCookie, getDomain } from '../../utils/networking';
 import { deleteAllArticles } from '../../utils/composer/api';
 
+const articleTitle = `Cypress Integration Testing Article ${Date.now()}`;
+
 describe('Workflow Integration Tests', () => {
   beforeEach(() => {
     checkVars();
@@ -14,13 +16,20 @@ describe('Workflow Integration Tests', () => {
   });
 
   it('Create an article from within Workflow', function () {
-    const articleTitle = `Cypress Integration Testing Article ${Date.now()}`;
     cy.server();
+    cy.route('/api/content').as('content');
+    cy.route({
+      method: 'POST',
+      url: '/api/stubs',
+    }).as('stubs');
     cy.route(`/api/content?text=${articleTitle.split(' ').join('+')}`).as(
       'searchForArticle'
     );
 
-    cy.visit(getDomain());
+    cy.visit(getDomain())
+      .wait('@content')
+      .get('.wf-loader', { timeout: 30000 })
+      .should('not.exist');
 
     // Create article
     cy.get('[wf-dropdown-toggle]').contains('Create new').click();
@@ -32,20 +41,23 @@ describe('Workflow Integration Tests', () => {
       .contains('Completed successfully!')
       .should('exist')
       .get('.close')
-      .click();
+      .click()
+      .wait('@stubs');
 
     // Search for it in Workflow
     cy.get('#testing-dashboard-toolbar-section-search').type(
       articleTitle + '{enter}'
     );
 
-    // Delete from within Workflow
+    // Click on search result
     cy.wait('@searchForArticle')
       .get('#testing-content-list-item-title-anchor-text')
       .contains(articleTitle)
+      .should('exist')
       .parent()
       .click();
 
+    // Delete from within Workflow
     cy.get('.drawer__toolbar-item--danger').click();
   });
 });

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -3,7 +3,6 @@ import { fetchAndSetCookie, getDomain } from '../../utils/networking';
 import { deleteAllArticles } from '../../utils/composer/api';
 
 const articleTitle = `Cypress Integration Testing Article ${Date.now()}`;
-
 describe('Workflow Integration Tests', () => {
   beforeEach(() => {
     checkVars();
@@ -22,7 +21,7 @@ describe('Workflow Integration Tests', () => {
       method: 'POST',
       url: '/api/stubs',
     }).as('stubs');
-    cy.route(`/api/content?text=${articleTitle.split(' ').join('+')}`).as(
+    cy.route(`/api/content?text=${articleTitle.replace(/\s/g, '+')}`).as(
       'searchForArticle'
     );
 


### PR DESCRIPTION
## What does this change?

This PR aims to improve Workflow test reliability by waiting for more requests before continuing:

* It waits for the first call for content to respond, then waits for the `loading...` modal to disappear
* After creating an article, it waits for `POST /api/stubs` to respond before searching
* Couple comments clarifying intentions

## How can we measure success?

The Workflow test flaps less, hopefully not at all!

## Do the relevant integration tests still pass?

[X] Tested against Workflow PROD

## Images
