### PR TITLE
Delete Workflow content after tests run

### DIFF
--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -42,7 +42,7 @@ describe('Workflow Integration Tests', () => {
       .contains('Completed successfully!')
       .should('be.visible')
       .get('.alert-danger')
-      .should('not.exist')
+      .should('not.be.visible')
       .get('.close')
       .click()
       .wait('@stubs');

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -1,17 +1,20 @@
 import { checkVars } from '../../utils/vars';
 import { fetchAndSetCookie, getDomain } from '../../utils/networking';
-import { deleteAllArticles } from '../../utils/composer/api';
+import { deleteArticlesFromWorkflow } from '../../utils/composer/api';
 
-const articleTitle = `Cypress Integration Testing Article ${Date.now()}`;
+const contentTitlePrefix = `Cypress Integration Testing Article`;
+const uniqueContentTitle = `${contentTitlePrefix} ${Date.now()}`;
+
 describe('Workflow Integration Tests', () => {
   beforeEach(() => {
     checkVars();
     fetchAndSetCookie({ visitDomain: false });
+    deleteArticlesFromWorkflow(contentTitlePrefix);
   });
 
   after(() => {
     fetchAndSetCookie({ visitDomain: false });
-    deleteAllArticles();
+    deleteArticlesFromWorkflow(contentTitlePrefix);
   });
 
   it('Create an article from within Workflow', function () {
@@ -21,7 +24,7 @@ describe('Workflow Integration Tests', () => {
       method: 'POST',
       url: '/api/stubs',
     }).as('stubs');
-    cy.route(`/api/content?text=${articleTitle.replace(/\s/g, '+')}`).as(
+    cy.route(`/api/content?text=${uniqueContentTitle.replace(/\s/g, '+')}`).as(
       'searchForArticle'
     );
 
@@ -33,25 +36,27 @@ describe('Workflow Integration Tests', () => {
     // Create article
     cy.get('[wf-dropdown-toggle]').contains('Create new').click();
     cy.get('#testing-dashboard-create-dropdown-Article').click();
-    cy.get('#stub_title').type(articleTitle);
+    cy.get('#stub_title').type(uniqueContentTitle);
     cy.get('#stub_section').select('Training');
     cy.get('#testing-create-in-composer').click();
     cy.get('.modal-dialog')
       .contains('Completed successfully!')
-      .should('exist')
+      .should('be.visible')
+      .get('.alert-danger')
+      .should('not.exist')
       .get('.close')
       .click()
       .wait('@stubs');
 
     // Search for it in Workflow
     cy.get('#testing-dashboard-toolbar-section-search').type(
-      articleTitle + '{enter}'
+      uniqueContentTitle + '{enter}'
     );
 
     // Click on search result
     cy.wait('@searchForArticle')
       .get('#testing-content-list-item-title-anchor-text')
-      .contains(articleTitle)
+      .contains(uniqueContentTitle)
       .should('exist')
       .parent()
       .click();

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -9,7 +9,6 @@ describe('Workflow Integration Tests', () => {
   beforeEach(() => {
     checkVars();
     fetchAndSetCookie({ visitDomain: false });
-    deleteArticlesFromWorkflow(contentTitlePrefix);
   });
 
   after(() => {

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -27,17 +27,9 @@ function deleteContent(id: string) {
   cy.request({
     url,
     method: 'DELETE',
-    failOnStatusCode: false,
     headers: {
       Origin: getDomain({ app: 'integration-tests' }),
     },
-  }).then((response) => {
-    if (response.status !== 404 && response.status !== 202) {
-      console.log('DELETE ERROR', response, url);
-      throw new Error(
-        `${response.status} (${response.statusText}) response from DELETE ${id}`
-      );
-    }
   });
 }
 
@@ -76,7 +68,6 @@ export const deleteArticlesFromWorkflow = (contentPrefix: string) => {
     '+'
   )}`;
   const origin = getDomain({ app: 'integration-tests' });
-  console.log(urlWithParams, origin);
 
   cy.request({
     url: urlWithParams,
@@ -85,11 +76,13 @@ export const deleteArticlesFromWorkflow = (contentPrefix: string) => {
       Origin: origin,
     },
   }).then((response) => {
-    const ids = JSON.parse(response.body)
-      .content?.Writers.filter(
-        (content: { published: boolean }) => !content.published
-      )
-      .map((_) => _.composerId);
+    const ids =
+      JSON.parse(response.body)
+        .content?.Writers?.filter(
+          (content: { published: boolean; wordCount: number }) =>
+            !content.published && content.wordCount === 0
+        )
+        .map((_) => _.composerId) || [];
 
     cy.log(
       `${ids.length} articles by ${env.user.email}, attempting to delete...`

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -54,9 +54,7 @@ export const deleteAllArticles = () => {
       `${contents.length} articles by ${env.user.email}, attempting to delete ${deletable.length} unpublished`
     );
 
-    deletable.forEach(({ data }) => {
-      deleteContent(data.id);
-    });
+    deletable.forEach(({ data }) => deleteContent(data.id));
   });
 };
 
@@ -72,9 +70,7 @@ export const deleteArticlesFromWorkflow = (contentPrefix: string) => {
   cy.request({
     url: urlWithParams,
     method: 'GET',
-    headers: {
-      Origin: origin,
-    },
+    headers: { Origin: origin },
   }).then((response) => {
     const ids =
       JSON.parse(response.body)
@@ -82,7 +78,7 @@ export const deleteArticlesFromWorkflow = (contentPrefix: string) => {
           (content: { published: boolean; wordCount: number }) =>
             !content.published && content.wordCount === 0
         )
-        .map((_) => _.composerId) || [];
+        .map((content: { composerId: string }) => content.composerId) || [];
 
     cy.log(
       `${ids.length} articles by ${env.user.email}, attempting to delete...`


### PR DESCRIPTION
## What does this change?

To be merged once this app is added to the allowed origins via this PR: https://github.com/guardian/workflow-frontend/pull/284

Workflow tests currently don't clean up after themselves, as the articles created don't get deleted by the `deleteAllArticles` fn (due to it not having the test user as a collaborator). 

This PR deletes all content created by the test user by: 

1. Getting all content matching the "Cypress Integration Testing Article" prefix (which is used to create all content)
2. Getting the Composer ID for each
3. Deleting them (as long as they have 0 word count and aren't published, in case they've been interfered with)

## How can we measure success?

We don't end up with this anymore:

![image](https://user-images.githubusercontent.com/25747336/90157918-3c956000-dd86-11ea-9a9e-0e4e58ac2d8f.png)

## Do the relevant integration tests still pass?

[X] Tested against Workflow CODE
