### PR TITLE
Wait for search response to process before continuing

### DIFF
--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -50,6 +50,7 @@ describe('Workflow Integration Tests', () => {
 
     // Click on search result
     cy.wait('@searchForArticle')
+      .wait(2000)
       .get('#testing-content-list-item-title-anchor-text')
       .contains(articleTitle)
       .should('exist')


### PR DESCRIPTION
## What does this change?

Workflow seems to flap trying to interact with the searched content, and this might be due to Workflow needing a second to render results before the search result shows up.

This PR gives Workflow 2 seconds to work it out, which should be enough given the test only occasionally flaps (suggesting it's normally enough time already).

## How can we measure success?

The Workflow test flaps less/never!

## Do the relevant integration tests still pass?

[X] Tested against Workflow CODE, Workflow PROD