### PR TITLE
Wait for Composer to load and make more assertions during test

### DIFF
--- a/cypress/integration/composer/integration.ts
+++ b/cypress/integration/composer/integration.ts
@@ -7,7 +7,7 @@ import { deleteAllArticles } from '../../utils/composer/api';
 describe('Composer Integration Tests', () => {
   beforeEach(() => {
     checkVars();
-    fetchAndSetCookie({ visitDomain: true });
+    fetchAndSetCookie({ visitDomain: false });
   });
 
   after(() => {

--- a/cypress/utils/composer/createArticle.ts
+++ b/cypress/utils/composer/createArticle.ts
@@ -13,5 +13,7 @@ export function createAndEditArticle() {
     .get('#js-dashboard-create-article')
     .click()
     .wait(2000)
+    .url()
+    .should('include', '/content/')
     .log('Article created');
 }

--- a/cypress/utils/composer/createArticle.ts
+++ b/cypress/utils/composer/createArticle.ts
@@ -1,6 +1,14 @@
+import { getDomain } from '../networking';
+import env from '../../../env.json';
+
 export function createAndEditArticle() {
-  return cy
-    .get('#js-dashboard-create-dropdown')
+  cy.server();
+  cy.route(`/api/content?collaboratorEmail=${env.user.email}**`).as(
+    'apiCollaborator'
+  );
+
+  cy.visit(getDomain()).wait('@apiCollaborator');
+  cy.get('#js-dashboard-create-dropdown')
     .click()
     .get('#js-dashboard-create-article')
     .click()

--- a/cypress/utils/composer/getId.ts
+++ b/cypress/utils/composer/getId.ts
@@ -3,5 +3,7 @@ import { getDomain } from '../networking';
 export function getId(url: string, options?: { app?: string; stage?: string }) {
   const domain = getDomain(options);
   cy.location('href').should('match', new RegExp(`${domain}/content\/`));
-  return url.split('/')[4];
+  const id = url.split('/')[4];
+  expect(id, 'article ID').to.not.be.undefined;
+  return id;
 }

--- a/cypress/utils/composer/inATemporaryArticle.ts
+++ b/cypress/utils/composer/inATemporaryArticle.ts
@@ -12,18 +12,17 @@ export function inATemporaryArticle(
   assertFn: fnArg = (id) => cy.log(`Checked nothing for id ${id}`)
 ) {
   it(`(In a temporary article) ${title}`, () => {
-    createAndEditArticle()
-      .url()
-      .then((url) => {
-        const id = getId(url);
-        startEditing();
-        cy.log('Article id is ', id);
-        editFn(id);
-        stopEditingAndClose();
-        cy.log('Closed the article');
-        assertFn(id);
-        // Go ahead and delete the article
-        deleteArticle(id);
-      });
+    createAndEditArticle();
+    cy.url().then((url) => {
+      const id = getId(url);
+      startEditing();
+      cy.log('Article id is ', id);
+      editFn(id);
+      stopEditingAndClose();
+      cy.log('Closed the article');
+      assertFn(id);
+      // Go ahead and delete the article
+      deleteArticle(id);
+    });
   });
 }


### PR DESCRIPTION
## What does this change?

Composer tests can be flaky, and it looks like this might be due to Cypress trying to create articles too quickly without waiting for Composer to load a bit first.

This PR makes sure wait for a couple API calls (it looks like `/api?collaboratorEmail=<>` is low down the chain) before continuing, and additionally waits for the URL to change to the content editor and makes assertions that everything is okay before continuing.

## How can we measure success?

The test should pass more, and, if it fails, we get better visibility on what went wrong.

## Do the relevant integration tests still pass?

[X] Tested against Composer CODE + PROD

## Images
