### PR TITLE
[REFACTOR] Extract Workflow actions to helper file

### DIFF
--- a/cypress/utils/workflow/interfaces.ts
+++ b/cypress/utils/workflow/interfaces.ts
@@ -1,0 +1,8 @@
+export interface WorkflowResponse {
+  [status: string]: {
+    published: boolean;
+    wordCount: number;
+    composerId: string;
+    lastModifiedBy: string;
+  }[];
+}

--- a/cypress/utils/workflow/utils.ts
+++ b/cypress/utils/workflow/utils.ts
@@ -1,0 +1,43 @@
+import { getDomain } from '../networking';
+import { defaultQueryString } from '../../integration/workflow/integration';
+
+export const visitWorkflow = (params = '') => {
+  const waitAlias =
+    '@content' +
+    (params === `/dashboard${defaultQueryString}` ? 'WithDefaultQuery' : '');
+
+  cy.visit(getDomain({ app: 'workflow' }) + params)
+    .wait(waitAlias)
+    .get('.wf-loader', { timeout: 30000 })
+    .should('not.exist');
+};
+
+export function createArticle(title: string) {
+  cy.get('[wf-dropdown-toggle]').contains('Create new').click();
+  cy.get('#testing-dashboard-create-dropdown-Article').click();
+  cy.get('#stub_title').type(title);
+  cy.get('#stub_section').select('Training');
+  cy.get('#testing-create-in-composer').click();
+  cy.get('.modal-dialog')
+    .contains('Completed successfully!')
+    .should('be.visible')
+    .get('.alert-danger')
+    .should('not.be.visible')
+    .get('.close')
+    .click()
+    .wait('@stubs');
+}
+
+export function searchFor(query: string) {
+  cy.get('#testing-dashboard-toolbar-section-search').type(query + '{enter}');
+}
+
+export function clickOnArticle(title: string) {
+  cy.wait('@searchForText')
+    .wait(2000)
+    .get('#testing-content-list-item-title-anchor-text')
+    .contains(title)
+    .should('exist')
+    .parent()
+    .click();
+}


### PR DESCRIPTION
## What does this change?

This PR refactors the Workflow test code to common behaviours (eg searching for text) that can be reused elsewhere. This will help when creating future tests.

It also improves the cleanup job by ensuring that all content from the test user is deleted, not just ones in the `Writers` section.

## How can we measure success?

The tests continue to pass and subsequent tests can make use of the helper functions created. Additionally, tests that move content from status to status will clean up after themselves.

## Do the relevant integration tests still pass?

[X] Tested against Workflow CODE

## Images
