### PR TITLE
Link to video in Pagerduty alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 videos
 screenshots
 *failures.txt
+*id.txt
 
 # Config
 *cookie.json

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -10,6 +10,7 @@ const suite = process.env.SUITE;
 const logFile = 'tests.json.log';
 const logDir = path.join(__dirname, '../logs');
 const failuresFile = path.join(__dirname, `../${suite}.failures.txt`);
+const idFile = path.join(__dirname, `../${suite}.id.txt`);
 const videoDir = path.join(__dirname, `../cypress/videos/${suite}`);
 
 const now = new Date();
@@ -22,6 +23,7 @@ const date = now.getDate();
 
   try {
     const failures = fs.readFileSync(failuresFile);
+    const uid = fs.readFileSync(idFile);
 
     if (failures > 0) {
       const credentials = config.isDev
@@ -35,7 +37,6 @@ const date = now.getDate();
       await Promise.all(
         videos.map(async (video) => {
           // Videos run every 5 minutes, so adding anything past the minute is unnecessary
-          const uid = new Date().toISOString().substr(0, 16);
 
           const key = `videos/${year}/${month}/${date}/${uid}-${suite}-${video}`;
 

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -34,7 +34,10 @@ const date = now.getDate();
 
       await Promise.all(
         videos.map(async (video) => {
-          const key = `videos/${year}/${month}/${date}/${new Date().toISOString()}-${suite}-${video}`;
+          // Videos run every 5 minutes, so adding anything past the minute is unnecessary
+          const uid = new Date().toISOString().substr(0, 16);
+
+          const key = `videos/${year}/${month}/${date}/${uid}-${suite}-${video}`;
 
           await uploadVideoToS3({
             credentials,


### PR DESCRIPTION
## What does this change?

At the minute, it can be hard to correlate a video of the run in a Pagerduty alert with the file in S3.

This PR makes the videos easier to read by dropping some of the superfluous information in the name, and links to the video in the Pagerduty alert so you can click through directly to the video when debugging.

## How can we measure success?

We can locate and watch videos of the broken runs more easily and quickly.

## Do the relevant integration tests still pass?

[X] Tested against Workflow CODE

## Images
