### PR TITLE
Improve logging in Pagerduty reporter and video uploading

### DIFF
--- a/cypress/utils/grid/api.ts
+++ b/cypress/utils/grid/api.ts
@@ -14,9 +14,15 @@ export async function deleteImages(
   cy: Cypress.cy & EventEmitter,
   images: string[]
 ) {
+  const stage =
+    Cypress.env('STAGE').toLowerCase() === 'code'
+      ? 'test'
+      : Cypress.env('STAGE');
+
   images.map((id: string) => {
     const cropper = `${getDomain({
       prefix: 'cropper',
+      stage: stage,
     })}/crops/${id}`;
     cy.request({
       method: 'DELETE',

--- a/cypress/utils/grid/api.ts
+++ b/cypress/utils/grid/api.ts
@@ -14,33 +14,23 @@ export async function deleteImages(
   cy: Cypress.cy & EventEmitter,
   images: string[]
 ) {
-  const stage =
-    Cypress.env('STAGE').toLowerCase() === 'code'
-      ? 'test'
-      : Cypress.env('STAGE');
+  const cropperDomain = getDomain({ prefix: 'cropper' });
+  const originDomain = getDomain({ app: 'integration-tests' });
+  const usagesDomain = getDomain({ app: 'media-usage' });
 
   images.map((id: string) => {
-    const cropper = `${getDomain({
-      prefix: 'cropper',
-      stage: stage,
-    })}/crops/${id}`;
+    const cropperUrl = `${cropperDomain}/crops/${id}`;
     cy.request({
       method: 'DELETE',
-      url: cropper,
-      headers: {
-        Origin: getDomain({ app: 'integration-tests' }),
-      },
+      url: cropperUrl,
+      headers: { Origin: originDomain },
     });
 
-    const usages = `${getDomain({
-      app: 'media-usage',
-    })}/usages/media/${id}`;
+    const usagesUrl = `${usagesDomain}/usages/media/${id}`;
     cy.request({
       method: 'DELETE',
-      url: usages,
-      headers: {
-        Origin: getDomain({ app: 'integration-tests' }),
-      },
+      url: usagesUrl,
+      headers: { Origin: originDomain },
     });
 
     cy.wait(500);
@@ -50,9 +40,7 @@ export async function deleteImages(
       method: 'DELETE',
       url,
       failOnStatusCode: false,
-      headers: {
-        Origin: getDomain({ app: 'integration-tests' }),
-      },
+      headers: { Origin: originDomain },
     }).then((response) => {
       if (response.status !== 404 && response.status !== 202) {
         console.log('DELETE ERROR', response, url);

--- a/reporters/pagerduty.js
+++ b/reporters/pagerduty.js
@@ -41,6 +41,10 @@ function Pagerduty(runner) {
 
       // Create run ID file that can be used by `uploadVideo.js`
       fs.writeFileSync(runIDFile, uid);
+      logger.log({
+        message: `Started - ${suite} with uid ${uid}`,
+        uid,
+      });
     });
 
     runner.on('pending', async function (test) {
@@ -48,6 +52,7 @@ function Pagerduty(runner) {
       passes++;
       console.log('Pending:', test.fullTitle());
       logger.log({
+        uid,
         testTitle: test.title,
         message,
         testContext: test.titlePath()[0],
@@ -61,6 +66,7 @@ function Pagerduty(runner) {
       passes++;
       console.log('Pass:', test.fullTitle());
       logger.log({
+        uid,
         testTitle: test.title,
         message,
         testContext: test.titlePath()[0],
@@ -79,6 +85,7 @@ function Pagerduty(runner) {
       failures++;
       console.error('Failure:', test.fullTitle(), err.message, '\n');
       logger.error({
+        uid,
         testTitle: test.title,
         message,
         testContext: test.titlePath()[0],
@@ -94,6 +101,7 @@ function Pagerduty(runner) {
         videosFolder: `https://s3.console.aws.amazon.com/s3/buckets/${env.videoBucket}/videos/${year}/${month}/${date}/?region=${region}&tab=overview`,
         videosAccount: env.aws.profile,
         video: `https://s3.console.aws.amazon.com/s3/object/${env.videoBucket}/videos/${year}/${month}/${date}/${uid}-${suite}-${video}.mp4`,
+        uid,
       });
     });
 

--- a/reporters/pagerduty.js
+++ b/reporters/pagerduty.js
@@ -124,6 +124,7 @@ function Pagerduty(runner) {
     logger.error({
       message: `Error - ${suite} [${uid}]: ${e.message}`,
       stackTrace: e.stack,
+      uid,
     });
   }
 }
@@ -160,6 +161,7 @@ async function callPagerduty(test, action, details = {}) {
       message: `PagerdutyReportError: ${json.message}`,
       error: json.errors,
       data,
+      uid,
     });
   }
 }

--- a/reporters/pagerduty.js
+++ b/reporters/pagerduty.js
@@ -108,6 +108,10 @@ function Pagerduty(runner) {
     runner.on('end', async function () {
       console.log('end: %d/%d', passes, passes + failures);
       fs.writeFileSync(failuresFile, failures);
+      logger.log({
+        message: `Ended - ${suite} with uid ${uid}`,
+        uid,
+      });
     });
   } catch (e) {
     logger.error(e);

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,8 +9,15 @@ function runTests() {
     SUITE=$1
     FAILURES_FILE="${DIR}/../${SUITE}.failures.txt"
     rm "${FAILURES_FILE}" || true
-    SUITE=${SUITE} STAGE="${STAGE}" npm run --silent cy:live || true
-    SUITE=${SUITE} STAGE="${STAGE}" node scripts/uploadVideo.js
+
+    if [[ $SUITE == "grid" && ($STAGE == "CODE" || $STAGE == "code")]]; then
+      REALSTAGE="test"
+    else
+      REALSTAGE="code"
+    fi
+
+    SUITE=${SUITE} STAGE="${REALSTAGE}" npm run --silent cy:live || true
+    SUITE=${SUITE} STAGE="${REALSTAGE}" node scripts/uploadVideo.js
 }
 
 "${DIR}"/setup.sh "${STAGE}"

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -20,10 +20,21 @@ const date = now.getDate();
 
 (async function f() {
   const logger = new Logger({ logDir, logFile });
+  let uid = null;
+
+  try {
+    uid = fs.readFileSync(idFile);
+  } catch (e) {
+    logger.error({
+      error: e.message,
+      message: `Failure to upload video ${videoDir}: Error reading UID file from ${idFile}: ${e.message}`,
+      stackTrace: e.stack,
+    });
+    return;
+  }
 
   try {
     const failures = fs.readFileSync(failuresFile);
-    const uid = fs.readFileSync(idFile);
 
     if (failures > 0) {
       const credentials = config.isDev
@@ -59,8 +70,9 @@ const date = now.getDate();
     }
   } catch (e) {
     logger.error({
-      message: `Error when attempting to upload video from [${videoDir}]: ${e.message}`,
+      message: `Error when attempting to upload video {${uid}} from [${videoDir}]: ${e.message}`,
       stackTrace: e.stack,
+      error: e.message,
     });
     console.error(e);
   }

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -29,6 +29,7 @@ const date = now.getDate();
       error: e.message,
       message: `Failure to upload video ${videoDir}: Error reading UID file from ${idFile}: ${e.message}`,
       stackTrace: e.stack,
+      uid,
     });
     return;
   }
@@ -59,17 +60,20 @@ const date = now.getDate();
           });
 
           logger.log({
+            uid,
             message: `Video [${key}] uploaded to ${config.videoBucket}`,
           });
         })
       );
     } else {
       logger.log({
+        uid,
         message: `No failures for suite ${suite}, not uploading video`,
       });
     }
   } catch (e) {
     logger.error({
+      uid,
       message: `Error when attempting to upload video {${uid}} from [${videoDir}]: ${e.message}`,
       stackTrace: e.stack,
       error: e.message,

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -58,7 +58,10 @@ const date = now.getDate();
       });
     }
   } catch (e) {
-    logger.error({ message: e.message, stackTrace: e.stack });
+    logger.error({
+      message: `Error when attempting to upload video from [${videoDir}]: ${e.message}`,
+      stackTrace: e.stack,
+    });
     console.error(e);
   }
 })();


### PR DESCRIPTION
## What does this change?

This adds some more logging to the service, as it is currently difficult to diagnose why certain problems with uploading videos occur. This is achieved by adding logs for when runs start and finish as well as making it clearer in logs what error is being reported and the consequences (eg failure to upload a video).

## How can we measure success?

We can debug what's going on with the video uploading and failure reporting more easily.

## Do the relevant integration tests still pass?

[X] Tested against Grid & Composer & Workflow CODE (Grid has some CORS issues when running `scripts/run.sh` locally but that can be fixed with config)