### PR TITLE
Run tests every 10 minutes to give tests more time to complete

### DIFF
--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -155,7 +155,7 @@ Resources:
           files:
             /etc/cron.d/run-integration-tests:
               content: !Sub |
-                */5 * * * * root /data/editorial-tools-integration-tests/scripts/run.sh ${Stage} >> /var/log/tests.log 2>&1
+                */10 * * * * root /data/editorial-tools-integration-tests/scripts/run.sh ${Stage} >> /var/log/tests.log 2>&1
 
             "/etc/logstash/conf.d/logstash.conf":
               content: !Sub |


### PR DESCRIPTION
## What does this change?

We have added more tests to the test runner and it appears that the tests occasionally take longer than 5 minutes. Since the tests run every 5 minutes, this then ends up with two instances of Cypress running concurrently which the current EC2 instance can't seem to handle.

This PR changes the test frequency to 10 minutes instead of 5, allowing us more time to add more integration tests and ensure the EC2 instance doesn't topple over.

In the future, we may have to additionally bump the EC2 instance to add more RAM/CPU if we can't avoid running multiple tests concurrently, but I think 10 minutes is still frequent enough to get good feedback.

## How can we measure success?

Integration tests continue to run even if tests take longer than 5 minutes.

## Do the relevant integration tests still pass?

[X] Tested against ALL 

## Images
