### PR TITLE
Get actual UID rather than buffer

### DIFF
--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -23,7 +23,7 @@ const date = now.getDate();
   let uid = null;
 
   try {
-    uid = fs.readFileSync(idFile).toString();
+    uid = fs.readFileSync(idFile, { encoding: 'utf8' });
   } catch (e) {
     logger.error({
       error: e.message,

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -23,7 +23,7 @@ const date = now.getDate();
   let uid = null;
 
   try {
-    uid = fs.readFileSync(idFile);
+    uid = fs.readFileSync(idFile).toString();
   } catch (e) {
     logger.error({
       error: e.message,


### PR DESCRIPTION
## What does this change?

Previously, we were accessing the UID string from a file by calling `fs.readFileSync()`. This returns a buffer, not a string. As a result, we were logging the wrong thing to ELK (the buffer object), which in turn seems to have broken the logs as ELK gets confused as to what type UID is.

This PR calls `.toString()` on the `readFileSync` so we get the actual string value rather than the buffer object.

## How can we measure success?

We see all logs show up successfully in ELK.

## Do the relevant integration tests still pass?

[X] Tested against ALL CODE

## Images
