### PR TITLE
Remove unused `visitDomain` functionality from `fetchAndSetCookie`

### DIFF
--- a/cypress/integration/composer/integration.ts
+++ b/cypress/integration/composer/integration.ts
@@ -7,7 +7,7 @@ import { deleteAllArticles } from '../../utils/composer/api';
 describe('Composer Integration Tests', () => {
   beforeEach(() => {
     checkVars();
-    fetchAndSetCookie({ visitDomain: false });
+    fetchAndSetCookie();
   });
 
   after(() => {

--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -29,18 +29,18 @@ function setupAliases() {
 describe('Grid Key User Journeys', function () {
   before(() => {
     checkVars();
-    fetchAndSetCookie({ visitDomain: false });
+    fetchAndSetCookie();
     deleteImages(cy, [getImageHash()]);
     resetCollection(cy, rootCollection);
   });
 
   beforeEach(() => {
-    fetchAndSetCookie({ visitDomain: false });
+    fetchAndSetCookie();
     setupAliases();
   });
 
   after(() => {
-    fetchAndSetCookie({ visitDomain: false });
+    fetchAndSetCookie();
     deleteImages(cy, [getImageHash()]);
     resetCollection(cy, rootCollection);
   });
@@ -202,7 +202,7 @@ describe('Grid Key User Journeys', function () {
 
     uploads.setRights('screengrab', Date.now().toString());
 
-    fetchAndSetCookie({ stage: composerStage, visitDomain: false });
+    fetchAndSetCookie(composerStage);
     cy.visit(composerUrl);
 
     createAndEditArticle();

--- a/cypress/integration/workflow/integration.ts
+++ b/cypress/integration/workflow/integration.ts
@@ -44,11 +44,11 @@ describe('Workflow Integration Tests', () => {
     uniqueContentTitle = `${contentTitlePrefix} ${Date.now()}`;
     setupRoutes(uniqueContentTitle);
     checkVars();
-    fetchAndSetCookie({ visitDomain: false });
+    fetchAndSetCookie();
   });
 
   after(() => {
-    fetchAndSetCookie({ visitDomain: false });
+    fetchAndSetCookie();
     deleteArticlesFromWorkflow(contentTitlePrefix);
   });
 

--- a/cypress/utils/networking.ts
+++ b/cypress/utils/networking.ts
@@ -21,31 +21,19 @@ export function getDomain(options?: GetDomainOptions) {
     : `https://${subdomain}.${stage}.dev-gutools.co.uk`;
 }
 
-export function setCookie(
-  cy: Cypress.cy & EventEmitter,
-  cookie: Cookie,
-  visitDomain = true
-) {
+export function setCookie(cy: Cypress.cy & EventEmitter, cookie: Cookie) {
   cy.setCookie('gutoolsAuth-assym', cookie.cookie, {
     domain: `.${cookie.domain}`,
     path: '/',
     secure: true,
     httpOnly: true,
   });
-
-  if (visitDomain) {
-    cy.visit(getDomain());
-    cy.wait(2);
-  }
 }
 
-export function fetchAndSetCookie({
-  visitDomain = true,
-  stage = Cypress.env('STAGE'),
-}) {
+export function fetchAndSetCookie(stage = Cypress.env('STAGE')) {
   return cy.task('getCookie', stage).then((cookie) => {
     expect(cookie).to.have.property('cookie');
     expect(cookie).to.have.property('domain');
-    return setCookie(cy, (cookie as unknown) as Cookie, visitDomain);
+    return setCookie(cy, (cookie as unknown) as Cookie);
   });
 }


### PR DESCRIPTION
## What does this change?

The `fetchAndSetCookie` and `setCookie` functions had the capacity to receive a `visitDomain` parameter, which, when `true`, would visit the domain after setting the cookie. This is no longer used anywhere and isn't useful (it's better to be explicit when visiting domains), so this PR removes it from the codebase.

## Do the relevant integration tests still pass?

[X] Tested against ALL CODE

## Images
