### PR TITLE
Move temporary files to `tmp/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 # Cypress
 videos
 screenshots
+tmp
 *failures.txt
 *id.txt
 

--- a/reporters/pagerduty.ts
+++ b/reporters/pagerduty.ts
@@ -8,9 +8,10 @@ import env from '../env.json';
 const suite = process.env.SUITE;
 
 const logDir = path.join(__dirname, '../logs');
+const tmpDir = path.join(__dirname, '../tmp');
 const logFile = 'tests.json.log';
-const failuresFile = path.join(__dirname, `../${suite}.failures.txt`);
-const runIDFile = path.join(__dirname, `../${suite}.id.txt`);
+const failuresFile = `${tmpDir}/${suite}.failures.txt`;
+const runIDFile = `${tmpDir}/${suite}.id.txt`;
 // Yields `YYYY-DD-MMTHH-MM`
 const uid = new Date().toISOString().substr(0, 16);
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,11 +4,16 @@ set -e
 
 STAGE=${1:-PROD}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="${DIR}/.."
+
+function resetTmpFiles() {
+    TMP_DIR="${ROOT_DIR}/tmp"
+    rm -r "${TMP_DIR}" || true
+    mkdir "${TMP_DIR}"
+}
 
 function runTests() {
     SUITE=$1
-    FAILURES_FILE="${DIR}/../${SUITE}.failures.txt"
-    rm "${FAILURES_FILE}" || true
 
     if [[ $SUITE == "grid" && ($STAGE == "CODE" || $STAGE == "code")]]; then
       REALSTAGE="test"
@@ -19,6 +24,8 @@ function runTests() {
     SUITE=${SUITE} STAGE="${REALSTAGE}" npm run --silent cy:live || true
     SUITE=${SUITE} STAGE="${REALSTAGE}" npm run upload-video
 }
+
+resetTmpFiles
 
 "${DIR}"/setup.sh "${STAGE}"
 

--- a/scripts/uploadVideo.ts
+++ b/scripts/uploadVideo.ts
@@ -9,8 +9,9 @@ const suite = process.env.SUITE;
 
 const logFile = 'tests.json.log';
 const logDir = path.join(__dirname, '../logs');
-const failuresFile = path.join(__dirname, `../${suite}.failures.txt`);
-const idFile = path.join(__dirname, `../${suite}.id.txt`);
+const tmpDir = path.join(__dirname, '../tmp');
+const failuresFile = path.join(`${tmpDir}/${suite}.failures.txt`);
+const idFile = path.join(`${tmpDir}/${suite}.id.txt`);
 const videoDir = path.join(__dirname, `../cypress/videos/${suite}`);
 
 const now = new Date();


### PR DESCRIPTION
## What does this change?

At the minute, the root directory of the app gets littered with `<APP>.id.txt` and `<APP>.failures.txt` files. These temporary files would be better placed in a dedicated folder, so this PR moves these files to a `tmp/` folder that gets deleted at the start of every test.

## How can we measure success?

You can run `scripts/run.sh` locally and enjoy a much neater project!

## Do the relevant integration tests still pass?

[X] Tested against ALL CODE (ran `scripts/run.sh`)

## Images
