### PR TITLE
Inject apps into getDomain() so we are more explicit

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,5 +1,0 @@
-{
-  "baseUrls": {
-    "grid": "media"
-  }
-}

--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -12,9 +12,11 @@ import { resetCollection } from '../../utils/grid/collections';
 import { createAndEditArticle } from '../../utils/composer/createArticle';
 import { getId } from '../../utils/composer/getId';
 import { deleteArticleFromManagement } from '../../utils/composer/deleteArticle';
+import { apps } from '../../utils/values';
 
-// ID of `cypress/fixtures/GridmonTestImage.png`
-const dragImageID = getImageHash();
+const { grid } = apps;
+
+const dragImageID = getImageHash(); // ID of `cypress/fixtures/GridmonTestImage.png`
 const rootCollection = 'Cypress Integration Testing';
 const date = Date.now().toString();
 const waits = { createCrop: 1000 };
@@ -46,7 +48,9 @@ describe('Grid Key User Journeys', function () {
   });
 
   it('Upload image, set rights, set metadata, create crop, delete all crops', function () {
-    const imageUrl = `${getDomain({ prefix: 'api' })}/images/${dragImageID}`;
+    const imageUrl = `${getDomain(grid, {
+      prefix: 'api',
+    })}/images/${dragImageID}`;
     const crop = {
       width: '900',
       height: '540',
@@ -54,13 +58,13 @@ describe('Grid Key User Journeys', function () {
       yValue: '581',
     };
 
-    const cropsUrl = `${getDomain({
+    const cropsUrl = `${getDomain(grid, {
       prefix: 'cropper',
     })}/crops/${getImageHash()}`;
 
     const cropID = `${crop.xValue}_${crop.yValue}_${crop.width}_${crop.height}`;
 
-    cy.visit(getDomain(), {
+    cy.visit(getDomain(grid), {
       onBeforeLoad(win) {
         cy.stub(win, 'prompt').returns('DELETE');
       },
@@ -87,7 +91,7 @@ describe('Grid Key User Journeys', function () {
     uploads.addImageToCollection('Cypress Integration Testing');
 
     cy.get(`ui-upload-jobs [href="/images/${dragImageID}"] img`).click();
-    cy.url().should('equal', `${getDomain()}/images/${dragImageID}`);
+    cy.url().should('equal', `${getDomain(grid)}/images/${dragImageID}`);
 
     cy.request('GET', imageUrl).then((res) => {
       // Assert that image is usable after rights are added
@@ -116,7 +120,9 @@ describe('Grid Key User Journeys', function () {
       `${getImageURL()}?crop=${cropID}`
     );
 
-    const url = `${getDomain({ prefix: 'cropper' })}/crops/${getImageHash()}`;
+    const url = `${getDomain(grid, {
+      prefix: 'cropper',
+    })}/crops/${getImageHash()}`;
     cy.request('GET', url).then((res) => {
       const cropsBeforeDelete = res.body.data;
       expect(
@@ -157,7 +163,7 @@ describe('Grid Key User Journeys', function () {
   it('User can create a child collection and delete it', () => {
     const childName = Date.now().toString();
 
-    cy.visit(getDomain());
+    cy.visit(getDomain(grid));
 
     // Click on collections panel
     cy.get('[data-cy=show-collections-panel]').should('exist').click();
@@ -186,12 +192,9 @@ describe('Grid Key User Journeys', function () {
       Cypress.env('STAGE').toLowerCase() === 'test'
         ? 'code'
         : Cypress.env('STAGE');
-    const composerUrl = getDomain({
-      app: 'composer',
-      stage: composerStage,
-    });
+    const composerUrl = getDomain(apps.composer, { stage: composerStage });
 
-    cy.visit(getDomain());
+    cy.visit(getDomain(grid));
 
     uploads.dragImageToGrid('GridmonTestImage.png');
     uploads.ensureImageUploadedCorrectly();
@@ -214,7 +217,7 @@ describe('Grid Key User Journeys', function () {
       cy.get('.add-item__icon__svg--image').should('exist').click();
 
       // Check Grid iframe is loaded
-      cy.frameLoaded('.embedded-grid-iframe', { url: getDomain() });
+      cy.frameLoaded('.embedded-grid-iframe', { url: getDomain(grid) });
 
       const imageID = getImageHash();
 

--- a/cypress/utils/composer/api.ts
+++ b/cypress/utils/composer/api.ts
@@ -1,6 +1,7 @@
 import { getDomain } from '../networking';
 import env from '../../../env.json';
 import { WorkflowResponse } from '../workflow/interfaces';
+import { apps } from '../values';
 
 interface Content {
   data: {
@@ -22,26 +23,26 @@ interface Content {
 }
 
 function deleteContent(id: string) {
-  const apiBaseUrl = `${getDomain({ app: 'composer' })}/api`;
+  const apiBaseUrl = `${getDomain(apps.composer)}/api`;
   const url = `${apiBaseUrl}/content/${id}`;
 
   cy.request({
     url,
     method: 'DELETE',
     headers: {
-      Origin: getDomain({ app: 'integration-tests' }),
+      Origin: getDomain('integration-tests'),
     },
   });
 }
 
 export const deleteAllArticles = () => {
-  const apiBaseUrl = `${getDomain({ app: 'composer' })}/api`;
+  const apiBaseUrl = `${getDomain(apps.composer)}/api`;
 
   cy.request({
     url: `${apiBaseUrl}/content?collaboratorEmail=${env.user.email}`,
     method: 'GET',
     headers: {
-      Origin: getDomain({ app: 'integration-tests' }),
+      Origin: getDomain('integration-tests'),
     },
   }).then(({ body: { data: contents } }: { body: { data: Content[] } }) => {
     const deletable = contents.filter(
@@ -60,13 +61,13 @@ export const deleteAllArticles = () => {
 };
 
 export const deleteArticlesFromWorkflow = (contentPrefix: string) => {
-  const workflowBaseUrl = `${getDomain({ app: 'workflow' })}/api/content`;
+  const workflowBaseUrl = `${getDomain(apps.workflow)}/api/content`;
 
   const urlWithParams = `${workflowBaseUrl}?text=${contentPrefix.replace(
     /\s/g,
     '+'
   )}`;
-  const origin = getDomain({ app: 'integration-tests' });
+  const origin = getDomain('integration-tests');
 
   cy.request({
     url: urlWithParams,

--- a/cypress/utils/composer/createArticle.ts
+++ b/cypress/utils/composer/createArticle.ts
@@ -1,5 +1,6 @@
 import { getDomain } from '../networking';
 import env from '../../../env.json';
+import { apps } from '../values';
 
 export function createAndEditArticle() {
   cy.server();
@@ -7,7 +8,7 @@ export function createAndEditArticle() {
     'apiCollaborator'
   );
 
-  cy.visit(getDomain()).wait('@apiCollaborator');
+  cy.visit(getDomain(apps.composer)).wait('@apiCollaborator');
   cy.get('#js-dashboard-create-dropdown')
     .click()
     .get('#js-dashboard-create-article')

--- a/cypress/utils/composer/deleteArticle.ts
+++ b/cypress/utils/composer/deleteArticle.ts
@@ -1,8 +1,9 @@
 import { getDomain } from '../networking';
+import { apps } from '../values';
 
 export function deleteArticle(
   id: string,
-  options?: { app?: string; stage?: string }
+  options: { app: string; stage?: string }
 ) {
   clickIntoArticle(id);
   deleteArticleFromManagement(id, options);
@@ -14,7 +15,7 @@ function clickIntoArticle(id: string) {
 
 export function deleteArticleFromManagement(
   id: string,
-  options?: { app?: string; stage?: string }
+  options: { app: string; stage?: string }
 ) {
   cy.get('#js-management-edit')
     .click()
@@ -23,5 +24,5 @@ export function deleteArticleFromManagement(
     .get('#js-content-information-delete')
     .click({ force: true })
     .url()
-    .should('equal', `${getDomain(options)}/`);
+    .should('equal', `${getDomain(apps.composer, options)}/`);
 }

--- a/cypress/utils/composer/expectPreview.ts
+++ b/cypress/utils/composer/expectPreview.ts
@@ -1,7 +1,8 @@
 import { getDomain } from '../networking';
+import { apps } from '../values';
 
 export function expectPreview(id: string, regex: RegExp) {
-  const url = `${getDomain()}/api/content/${id}/preview`;
+  const url = `${getDomain(apps.composer)}/api/content/${id}/preview`;
   cy.request('GET', url).then((res) => {
     const content1 = res.body;
     expect(content1, 'the json content').to.not.be.undefined;

--- a/cypress/utils/composer/getId.ts
+++ b/cypress/utils/composer/getId.ts
@@ -1,7 +1,9 @@
 import { getDomain } from '../networking';
 
-export function getId(url: string, options?: { app?: string; stage?: string }) {
-  const domain = getDomain(options);
+export function getId(url: string, options: { app: string; stage?: string }) {
+  const domain = options.stage
+    ? getDomain(options.app, { stage: options.stage })
+    : getDomain(options.app);
   cy.location('href').should('match', new RegExp(`${domain}/content\/`));
   const id = url.split('/')[4];
   expect(id, 'article ID').to.not.be.undefined;

--- a/cypress/utils/composer/inATemporaryArticle.ts
+++ b/cypress/utils/composer/inATemporaryArticle.ts
@@ -3,6 +3,7 @@ import { stopEditingAndClose } from './stopEditingAndClose';
 import { deleteArticle } from './deleteArticle';
 import { getId } from './getId';
 import { startEditing } from './startEditing';
+import { apps } from '../values';
 
 type fnArg = (id: string) => void;
 
@@ -14,7 +15,7 @@ export function inATemporaryArticle(
   it(`(In a temporary article) ${title}`, () => {
     createAndEditArticle();
     cy.url().then((url) => {
-      const id = getId(url);
+      const id = getId(url, { app: apps.composer });
       startEditing();
       cy.log('Article id is ', id);
       editFn(id);
@@ -22,7 +23,7 @@ export function inATemporaryArticle(
       cy.log('Closed the article');
       assertFn(id);
       // Go ahead and delete the article
-      deleteArticle(id);
+      deleteArticle(id, { app: apps.composer });
     });
   });
 }

--- a/cypress/utils/grid/api.ts
+++ b/cypress/utils/grid/api.ts
@@ -1,4 +1,7 @@
 import { getDomain } from '../networking';
+import { apps } from '../values';
+const { grid } = apps;
+
 // hash of the image in assets/GridmonTestImage.png
 export const imageHash = 'fe052e21c4bc4d76a2c841d97c5b2281cccd19bd';
 
@@ -7,16 +10,16 @@ export function getImageHash() {
 }
 
 export function getImageURL() {
-  return `${getDomain()}/images/${getImageHash()}`;
+  return `${getDomain(grid)}/images/${getImageHash()}`;
 }
 
 export async function deleteImages(
   cy: Cypress.cy & EventEmitter,
   images: string[]
 ) {
-  const cropperDomain = getDomain({ prefix: 'cropper' });
-  const originDomain = getDomain({ app: 'integration-tests' });
-  const usagesDomain = getDomain({ app: 'media-usage' });
+  const cropperDomain = getDomain(grid, { prefix: 'cropper' });
+  const originDomain = getDomain('integration-tests');
+  const usagesDomain = getDomain('media-usage');
 
   images.map((id: string) => {
     const cropperUrl = `${cropperDomain}/crops/${id}`;
@@ -35,7 +38,7 @@ export async function deleteImages(
 
     cy.wait(500);
 
-    const url = `${getDomain({ prefix: 'api' })}/images/${id}`;
+    const url = `${getDomain(grid, { prefix: 'api' })}/images/${id}`;
     cy.request({
       method: 'DELETE',
       url,

--- a/cypress/utils/grid/collections.ts
+++ b/cypress/utils/grid/collections.ts
@@ -52,14 +52,14 @@ export function deleteChild(collection: string, child: string) {
 }
 
 export function resetCollection(cy: Cypress.cy, rootCollection: string) {
-  const url = `${getDomain({ app: 'media-collections' })}/collections`;
+  const url = `${getDomain('media-collections')}/collections`;
   // Delete collection
   const rootCollectionUrl = `${url}/${encodeURIComponent(rootCollection)}`;
   cy.request({
     method: 'DELETE',
     url: rootCollectionUrl,
     headers: {
-      Origin: getDomain({ app: 'integration-tests' }),
+      Origin: getDomain('integration-tests'),
     },
   });
   cy.request({
@@ -68,7 +68,7 @@ export function resetCollection(cy: Cypress.cy, rootCollection: string) {
     body: JSON.stringify({ data: rootCollection }),
     headers: {
       'Content-Type': 'application/json',
-      Origin: getDomain({ app: 'integration-tests' }),
+      Origin: getDomain('integration-tests'),
     },
   });
 }

--- a/cypress/utils/networking.ts
+++ b/cypress/utils/networking.ts
@@ -1,4 +1,4 @@
-import { baseUrls } from '../../cypress.env.json';
+import { apps } from './values';
 
 interface Cookie {
   cookie: string;
@@ -6,15 +6,13 @@ interface Cookie {
 }
 
 interface GetDomainOptions {
-  app?: string;
   prefix?: string;
   stage?: string;
 }
 
-export function getDomain(options?: GetDomainOptions) {
+export function getDomain(app: string, options?: GetDomainOptions) {
   const stage = options?.stage || Cypress.env('STAGE').toLowerCase();
-  const app = options?.app || Cypress.env('APP');
-  const appName = baseUrls[app] || app;
+  const appName = apps[app] || app;
   const subdomain = options?.prefix ? options.prefix + '.' + appName : appName;
   return stage.toLowerCase() === 'prod'
     ? `https://${subdomain}.gutools.co.uk`

--- a/cypress/utils/values.ts
+++ b/cypress/utils/values.ts
@@ -1,0 +1,13 @@
+interface Apps {
+  composer: string;
+  grid: string;
+  workflow: string;
+}
+
+// This maps the app to the base URL,
+// primarily used by `getDomain()` to create base URLs
+export const apps: Apps = {
+  composer: 'composer',
+  grid: 'media',
+  workflow: 'workflow',
+};

--- a/cypress/utils/workflow/utils.ts
+++ b/cypress/utils/workflow/utils.ts
@@ -1,12 +1,13 @@
 import { getDomain } from '../networking';
 import { defaultQueryString } from '../../integration/workflow/integration';
+import { apps } from '../values';
 
 export const visitWorkflow = (params = '') => {
   const waitAlias =
     '@content' +
     (params === `/dashboard${defaultQueryString}` ? 'WithDefaultQuery' : '');
 
-  cy.visit(getDomain({ app: 'workflow' }) + params)
+  cy.visit(getDomain(apps.workflow) + params)
     .wait(waitAlias)
     .get('.wf-loader', { timeout: 30000 })
     .should('not.exist');


### PR DESCRIPTION
## What does this change?

At the moment, we pass the `$APP` env variable at the command-line or in npm scripts. This is good for allowing abstraction, but poses limitations:

- We can't run all the suites at the same time within the same Cypres run (you have to run `./scripts/start.sh $APP $STAGE` per app)
- It's not always clear which domain you are getting from `getDomain()`, and I think the benefits outweigh the costs of being explicit
- When we write tests that use multiple apps (eg composer -> grid integrations), we'll need to be explicit, so having the app as optional might introduce confusion

This PR changes the signature of `getDomain` from `getDomain(options?)` to `getDomain(app, options?)` so you always have to pass the app. The app names are sourced from a new `values.ts` file that maps the app to the base URL you want.

## How can we measure success?

The integration tests run as normal, tests are easier to read and write

## Do the relevant integration tests still pass?

[X] Tested against ALL CODE

## Images
