### PR TITLE
Update apt-get before installing

### DIFF
--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -212,6 +212,7 @@ Resources:
           # Install Cypress dependencies
           apt install -y npm
           npm install --global yarn
+          apt-get update
           apt-get -y install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
           /data/editorial-tools-integration-tests/node_modules/cypress/bin/cypress install
 


### PR DESCRIPTION
## What does this change?

The integration tests stopped running yesterday. This is due to the instance not completing its `cloud-init` script, which was due to the `apt-get` registry not being up to date.

This PR adds running `apt-get update` before installing all packages for Cypress, ensuring the registry is up-to-date.

## How can we measure success?

The instance doesn't fail in the cloud-init stage (would have to ssh and check logs).