### PR TITLE
Add Cloudwatch alarms for integration test failures

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -1,5 +1,5 @@
 import * as cdk from '@aws-cdk/core';
-import { Fn, Stack, Tags, Duration } from '@aws-cdk/core';
+import { Duration, Fn, Stack, Tags } from '@aws-cdk/core';
 import {
   CfnInstanceProfile,
   Effect,
@@ -13,7 +13,15 @@ import {
   CfnLaunchConfiguration,
 } from '@aws-cdk/aws-autoscaling';
 import { CfnSecurityGroup } from '@aws-cdk/aws-ec2';
-import { Alarm, Metric } from '@aws-cdk/aws-cloudwatch';
+import {
+  Alarm,
+  ComparisonOperator,
+  Metric,
+  TreatMissingData,
+} from '@aws-cdk/aws-cloudwatch';
+import { SubscriptionProtocol, Topic } from '@aws-cdk/aws-sns';
+import { SnsAction } from '@aws-cdk/aws-cloudwatch-actions';
+import { UrlSubscription } from '@aws-cdk/aws-sns-subscriptions';
 
 const SUITES = ['Grid', 'Composer', 'Workflow'];
 const DIST_BUCKET = 'editorial-tools-integration-tests-dist';
@@ -58,9 +66,15 @@ export class CdkStack extends cdk.Stack {
         description:
           'The name (NOT arn) of the Kinesis stream that logs should be shipped to',
       }),
+      alertWebhook: new cdk.CfnParameter(this, 'AlertWebhook', {
+        type: 'String',
+        description: 'The webhook for the SNS alert topic to send to Pagerduty',
+      }),
     };
 
-    Tags.of(this).add('Stage', params.stage.valueAsString);
+    const stage = params.stage.valueAsString;
+
+    Tags.of(this).add('Stage', stage);
     Tags.of(this).add('Stack', params.stack.valueAsString);
 
     const loggingRoleParam = new cdk.CfnParameter(
@@ -179,6 +193,18 @@ export class CdkStack extends cdk.Stack {
       { groupDescription: 'HTTP', vpcId: params.vpcId.valueAsString }
     );
 
+    const pagerdutyTopic = new Topic(this, 'pagerduty-sns', {
+      displayName: `pagerduty-integration-tests-${stage.toUpperCase()}`,
+    });
+
+    pagerdutyTopic.addSubscription(
+      new UrlSubscription(params.alertWebhook.valueAsString, {
+        protocol: SubscriptionProtocol.HTTPS,
+      })
+    );
+
+    const snsAction = new SnsAction(pagerdutyTopic);
+
     SUITES.map((suite) => {
       const appName = `editorial-tools-integration-tests-${suite.toLowerCase()}`;
       const userData = Fn.base64(`#!/bin/bash -ev
@@ -189,7 +215,7 @@ attach-ebs-volume -d k -m /data
 
 
 # Set up the tests and their dependencies
-aws s3 cp s3://${DIST_BUCKET}/media-service/${params.stage.valueAsString}/${appName}/${appName}.zip /tmp/${appName}.zip
+aws s3 cp s3://${DIST_BUCKET}/media-service/${stage}/${appName}/${appName}.zip /tmp/${appName}.zip
 unzip -q /tmp/${appName}.zip -d /data/${appName}
 
 # Install Cypress dependencies
@@ -229,9 +255,7 @@ systemctl start logstash
           files: {
             '/etc/cron.d/run-integration-tests': {
               content: `
-*/4 * * * * root /data/${appName}/scripts/run.sh ${
-                params.stage.valueAsString
-              } ${suite.toLowerCase()} >> /var/log/tests.log 2>&1
+*/4 * * * * root /data/${appName}/scripts/run.sh ${stage} ${suite.toLowerCase()} >> /var/log/tests.log 2>&1
 `,
             },
             '/etc/logstash/conf.d/logstash.conf': {
@@ -248,7 +272,7 @@ systemctl start logstash
           add_field => {
             "app" => "${appName}"
             "stack" => "media-service"
-            "stage" => "${params.stage.valueAsString}"
+            "stage" => "${stage}"
           }
         }
       }
@@ -276,7 +300,7 @@ systemctl start logstash
           {
             key: 'Stage',
             propagateAtLaunch: true,
-            value: params.stage.valueAsString,
+            value: stage,
           },
           {
             key: 'Stack',
@@ -302,13 +326,20 @@ systemctl start logstash
         period: Duration.minutes(4),
       });
 
-      new Alarm(this, `failures-alarm-${suite.toLowerCase()}`, {
+      const alarm = new Alarm(this, `failures-alarm-${suite.toLowerCase()}`, {
         alarmDescription: `More than 3 failures out of 10 for ${suite}`,
         datapointsToAlarm: 3,
         evaluationPeriods: 10,
+        comparisonOperator:
+          ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         metric: metric,
         threshold: 1,
+        actionsEnabled: true,
+        treatMissingData: TreatMissingData.BREACHING,
       });
+      alarm.addAlarmAction(snsAction);
+      alarm.addOkAction(snsAction);
+      alarm.addInsufficientDataAction(snsAction);
     });
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -21,9 +21,10 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "^1.63.0",
-    "@aws-cdk/aws-ec2": "^1.63.0",
-    "@aws-cdk/aws-iam": "^1.63.0",
+    "@aws-cdk/aws-autoscaling": "1.63.0",
+    "@aws-cdk/aws-cloudwatch": "1.63",
+    "@aws-cdk/aws-ec2": "1.63.0",
+    "@aws-cdk/aws-iam": "1.63.0",
     "@aws-cdk/core": "1.63.0",
     "source-map-support": "^0.5.16"
   }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -23,8 +23,11 @@
   "dependencies": {
     "@aws-cdk/aws-autoscaling": "1.63.0",
     "@aws-cdk/aws-cloudwatch": "1.63",
+    "@aws-cdk/aws-cloudwatch-actions": "1.63",
     "@aws-cdk/aws-ec2": "1.63.0",
     "@aws-cdk/aws-iam": "1.63.0",
+    "@aws-cdk/aws-sns": "1.63",
+    "@aws-cdk/aws-sns-subscriptions": "1.63",
     "@aws-cdk/core": "1.63.0",
     "source-map-support": "^0.5.16"
   }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -42,7 +42,7 @@
     "@aws-cdk/core" "1.63.0"
     constructs "^3.0.4"
 
-"@aws-cdk/aws-autoscaling@^1.63.0":
+"@aws-cdk/aws-autoscaling@1.63.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.63.0.tgz#97b0b5e391e4a645c2f0c747b553179b0250b3a8"
   integrity sha512-LUFgCM4BIhgf8c1q8yglgU759qxl+SA1BHPis+5mDUKlDZS0Wx1Rpo7O2JKql1IpU1lPvs0joONN6Hg0fktAow==
@@ -68,7 +68,7 @@
     "@aws-cdk/core" "1.63.0"
     constructs "^3.0.4"
 
-"@aws-cdk/aws-cloudwatch@1.63.0":
+"@aws-cdk/aws-cloudwatch@1.63", "@aws-cdk/aws-cloudwatch@1.63.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.63.0.tgz#9f2bc95689b56bca688c60775d3211556aaff95d"
   integrity sha512-evM2B+Q7ou3SGQsf+yS/SyAm82EKhEndllxXQSFDBSnoNGzl+s8jzebIAXay/2o1+5kj4/sv8p6Itxg+XsZKYQ==
@@ -85,7 +85,7 @@
     "@aws-cdk/aws-iam" "1.63.0"
     "@aws-cdk/core" "1.63.0"
 
-"@aws-cdk/aws-ec2@1.63.0", "@aws-cdk/aws-ec2@^1.63.0":
+"@aws-cdk/aws-ec2@1.63.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.63.0.tgz#30396cd22748e33655b6cb1d518215e1f6438df5"
   integrity sha512-EXijZZbEoRtjyf/53Tw0GA49IgCuiMfueldSNyUKXgQbiYmwmi+oJPDSsYKkxaLCd/E5G3aqIlI/gpHDR3SuUg==
@@ -148,7 +148,7 @@
     "@aws-cdk/core" "1.63.0"
     constructs "^3.0.4"
 
-"@aws-cdk/aws-iam@1.63.0", "@aws-cdk/aws-iam@^1.63.0":
+"@aws-cdk/aws-iam@1.63.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.63.0.tgz#5bea211498a81e2c7f19e7e7d335e663195af02d"
   integrity sha512-d+kkz9I9v5an3RrsmOhXxyQLop/SB90YoDfmpd9JdKkDyMGSZN+e5IMvqye0iGC7rfA6tkVQb9tVEBdlXvZbZQ==

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -68,6 +68,19 @@
     "@aws-cdk/core" "1.63.0"
     constructs "^3.0.4"
 
+"@aws-cdk/aws-cloudwatch-actions@1.63":
+  version "1.63.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.63.0.tgz#3fbf402dd41ae24334c70227d436b3219c5975be"
+  integrity sha512-gTXfzTnDZhQ0X4xXYa6s9W83+o9paROF+x4BE8/R3lfnS6e1ITgpaX29E7IGXxg/9aEhceYchWNKKxHcEG+TyA==
+  dependencies:
+    "@aws-cdk/aws-applicationautoscaling" "1.63.0"
+    "@aws-cdk/aws-autoscaling" "1.63.0"
+    "@aws-cdk/aws-cloudwatch" "1.63.0"
+    "@aws-cdk/aws-iam" "1.63.0"
+    "@aws-cdk/aws-sns" "1.63.0"
+    "@aws-cdk/core" "1.63.0"
+    constructs "^3.0.4"
+
 "@aws-cdk/aws-cloudwatch@1.63", "@aws-cdk/aws-cloudwatch@1.63.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.63.0.tgz#9f2bc95689b56bca688c60775d3211556aaff95d"
@@ -232,7 +245,19 @@
     "@aws-cdk/core" "1.63.0"
     constructs "^3.0.4"
 
-"@aws-cdk/aws-sns@1.63.0":
+"@aws-cdk/aws-sns-subscriptions@1.63":
+  version "1.63.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.63.0.tgz#6337503ddabf2a9112ff5baeea9ce80f7c4a5b96"
+  integrity sha512-W14D7htxPteoW2u+RaRlFmO+HGoG02tR/p00De6BtaRQKQar4zpVOQfIW2AuUyv4eeuCEg16cRwSZP8cBUxOCg==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.63.0"
+    "@aws-cdk/aws-lambda" "1.63.0"
+    "@aws-cdk/aws-sns" "1.63.0"
+    "@aws-cdk/aws-sqs" "1.63.0"
+    "@aws-cdk/core" "1.63.0"
+    constructs "^3.0.4"
+
+"@aws-cdk/aws-sns@1.63", "@aws-cdk/aws-sns@1.63.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.63.0.tgz#4960cca7ce1a617ac1ae844363eddc6feecf85d8"
   integrity sha512-x93WSxLhx5F/T5TZ/im/5QUwZRiHMOGqrsiNvEwbaqWoGCMbZOxLRn5Aqy8ApPUxHPs6//+ck9qwme1EFsO7TA==

--- a/reporters/pagerduty.ts
+++ b/reporters/pagerduty.ts
@@ -65,7 +65,7 @@ function Pagerduty(runner: Mocha.Runner) {
         testState: 'pending',
       });
       await putMetric({ suite, test, result: 'pending' });
-      await callPagerduty(test, 'resolve');
+      await callPagerduty({ test, action: 'resolve', uid });
     });
 
     runner.on('pass', async function (test) {
@@ -80,7 +80,7 @@ function Pagerduty(runner: Mocha.Runner) {
         testState: 'pass',
       });
       await putMetric({ suite, test, result: 'pass' });
-      await callPagerduty(test, 'resolve');
+      await callPagerduty({ test, action: 'resolve', uid });
     });
 
     runner.on('fail', async function (test, err) {
@@ -103,12 +103,17 @@ function Pagerduty(runner: Mocha.Runner) {
 
       const video = getVideoName(<Mocha.Suite>test.parent); // TODO: Think of a way to surface this information in CW so that we can correlate alarms, logs and metrics
       await putMetric({ suite, test, result: 'fail' });
-      await callPagerduty(test, 'trigger', {
-        error: err.message,
-        videosFolder: `https://s3.console.aws.amazon.com/s3/buckets/${env.videoBucket}/videos/${year}/${month}/${date}/?region=${region}&tab=overview`,
-        videosAccount: env.aws.profile,
-        video: `https://s3.console.aws.amazon.com/s3/object/${env.videoBucket}/videos/${year}/${month}/${date}/${uid}-${suite}-${video}.mp4`,
+      await callPagerduty({
         uid,
+        test,
+        action: 'trigger',
+        details: {
+          error: err.message,
+          videosFolder: `https://s3.console.aws.amazon.com/s3/buckets/${env.videoBucket}/videos/${year}/${month}/${date}/?region=${region}&tab=overview`,
+          videosAccount: env.aws.profile,
+          video: `https://s3.console.aws.amazon.com/s3/object/${env.videoBucket}/videos/${year}/${month}/${date}/${uid}-${suite}-${video}.mp4`,
+          uid,
+        },
       });
     });
 

--- a/scripts/generate-cfn.sh
+++ b/scripts/generate-cfn.sh
@@ -7,7 +7,7 @@ ROOT_DIR="${DIR}/.."
 OUTPUT_DIR="${ROOT_DIR}/cloudformation/cdk"
 
 pushd "${ROOT_DIR}"/cdk || exit
-yarn
+yarn --silent
 rm "${OUTPUT_DIR}" || true
 yarn cdk synth -o "${OUTPUT_DIR}"
 popd

--- a/scripts/uploadVideo.ts
+++ b/scripts/uploadVideo.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { Logger } from '../src/utils/logger';
 import { uploadVideoToS3 } from '../src/utils/s3';
 import config from '../env.json';
+import env from '../env.json';
 
 const suite = process.env.SUITE;
 
@@ -65,6 +66,7 @@ const date = now.getDate();
           logger.log({
             uid,
             message: `Video [${key}] uploaded to ${config.videoBucket}`,
+            video: `https://s3.console.aws.amazon.com/s3/object/${env.videoBucket}/${key}.mp4`,
           });
         })
       );

--- a/src/utils/reporters.ts
+++ b/src/utils/reporters.ts
@@ -26,7 +26,6 @@ export function getVideoName(parent: Mocha.Suite): string {
 }
 
 export async function putMetric({
-  test,
   suite,
   result,
 }: {
@@ -34,7 +33,6 @@ export async function putMetric({
   suite: string | undefined;
   result: string;
 }) {
-  const testContext = test.titlePath()[0];
   const metricValue = result === 'fail' ? 1 : 0;
   const credentials = env.isDev
     ? new AWS.SharedIniFileCredentials({
@@ -70,11 +68,17 @@ export async function getCloudWatchClient(
     : new AWS.CloudWatch({ region: 'eu-west-1' });
 }
 
-export async function callPagerduty(
-  test: mocha.Test,
-  action: string,
-  details = {}
-) {
+export async function callPagerduty({
+  test,
+  action,
+  details,
+  uid,
+}: {
+  test: mocha.Test;
+  action: string;
+  uid: string;
+  details?: { [d: string]: string | number };
+}) {
   const url = 'https://events.pagerduty.com/v2/enqueue';
 
   const data = {
@@ -88,7 +92,7 @@ export async function callPagerduty(
       timestamp: new Date().toISOString(),
       component: 'Editorial Tools Integration Tests',
       links: 'https://gu.com',
-      custom_details: details,
+      custom_details: details || {},
     },
   };
 

--- a/src/utils/reporters.ts
+++ b/src/utils/reporters.ts
@@ -9,6 +9,7 @@ import path from 'path';
 const logDir = path.join(__dirname, '../logs');
 const logFile = 'tests.json.log';
 const routingKey = env.pagerduty.routingKey;
+const stage = process.env.STAGE;
 
 const logger = new Logger({ logDir, logFile });
 
@@ -53,6 +54,7 @@ export async function putMetric({
           { Name: 'testName', Value: test.title },
           { Name: 'testContext', Value: testContext },
           { Name: 'testState', Value: result },
+          { Name: 'stage', Value: stage?.toUpperCase() || 'UNKNOWN' },
         ],
         Timestamp: new Date(),
         Value: metricValue,

--- a/src/utils/reporters.ts
+++ b/src/utils/reporters.ts
@@ -49,11 +49,7 @@ export async function putMetric({
       {
         MetricName: 'Test Result',
         Dimensions: [
-          { Name: 'uid', Value: `${suite}-${testContext}-${test.title}` },
           { Name: 'suite', Value: suite ?? 'suite-missing' },
-          { Name: 'testName', Value: test.title },
-          { Name: 'testContext', Value: testContext },
-          { Name: 'testState', Value: result },
           { Name: 'stage', Value: stage?.toUpperCase() || 'UNKNOWN' },
         ],
         Timestamp: new Date(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,292 +2,6 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assets@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.63.0.tgz#87eeeda76538eb99f8b9838cfc6887d208edd900"
-  integrity sha512-KJU+W8uB0MCGY5pqNgEE3uOEwkdEYL3V37IIzKBc5UfLdADzYfaDQ/L9pbCLvzduAg7moOh7atw59WrqQUn1zA==
-  dependencies:
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/cx-api" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-applicationautoscaling@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.63.0.tgz#42b6b9ed5b9262d41110d9eb6e0e644ee60728d9"
-  integrity sha512-HIsShlgVOj3mEa5CsrySE8P2XElpvIcH6Sw6ZmhWNdg5tLDXGan4mit2apYL+zuiGcgeBZ/C9eArgWi/w+/6+A==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.63.0"
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-autoscaling-common@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.63.0.tgz#82306191b468b9f2634002dd11f6b79bdd2c90f0"
-  integrity sha512-Uhj8v1lJjKiEesMc4Y6TRcppkeYqgiP/UkjndpwAsbDyOdyThEEH8GS1Ird6MVqvtHvbfnUf6QdTzCrIDoOOkg==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-autoscaling@^1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.63.0.tgz#97b0b5e391e4a645c2f0c747b553179b0250b3a8"
-  integrity sha512-LUFgCM4BIhgf8c1q8yglgU759qxl+SA1BHPis+5mDUKlDZS0Wx1Rpo7O2JKql1IpU1lPvs0joONN6Hg0fktAow==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.63.0"
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-ec2" "1.63.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.63.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-sns" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-certificatemanager@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.63.0.tgz#b7425cb4156efd8a5063d4e0dc64a8a147ec52b2"
-  integrity sha512-bgfAtdanJJwIsPX2SRvJk8Go5+v6FTu38USk1/yxHePGUhs+NllPZrrCCD8buKyXdobGG0DDWYbHWPhbigUHOA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-lambda" "1.63.0"
-    "@aws-cdk/aws-route53" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-cloudwatch@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.63.0.tgz#9f2bc95689b56bca688c60775d3211556aaff95d"
-  integrity sha512-evM2B+Q7ou3SGQsf+yS/SyAm82EKhEndllxXQSFDBSnoNGzl+s8jzebIAXay/2o1+5kj4/sv8p6Itxg+XsZKYQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-codeguruprofiler@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.63.0.tgz#c62c8c38db936c55ff3fb035b09aeccb1d79b2c6"
-  integrity sha512-H2Jxc4CwmtUVkVTKqxZz5kYqJVhXeHMkZCzjCWtO/EjuLCI4VO2CWezkXOtVi3UCIJhwdg4vZ/uKy6zZj9EHPw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-
-"@aws-cdk/aws-ec2@1.63.0", "@aws-cdk/aws-ec2@^1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.63.0.tgz#30396cd22748e33655b6cb1d518215e1f6438df5"
-  integrity sha512-EXijZZbEoRtjyf/53Tw0GA49IgCuiMfueldSNyUKXgQbiYmwmi+oJPDSsYKkxaLCd/E5G3aqIlI/gpHDR3SuUg==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/aws-logs" "1.63.0"
-    "@aws-cdk/aws-s3" "1.63.0"
-    "@aws-cdk/aws-s3-assets" "1.63.0"
-    "@aws-cdk/aws-ssm" "1.63.0"
-    "@aws-cdk/cloud-assembly-schema" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/cx-api" "1.63.0"
-    "@aws-cdk/region-info" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-efs@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.63.0.tgz#bfdbab1e0c813bd798b7e61d43be48bfd501069f"
-  integrity sha512-goq0Ogy0tWtUpmJMMU36loJHVDM7dqipsxfuq9e4vck6x/mNh7jGdz6/L0INEi+771BwnXlOKAqttb414UYm4g==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/cloud-assembly-schema" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/cx-api" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-elasticloadbalancing@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.63.0.tgz#85d4cc2c4118d152c2ad6a84f0b93c1f93ec692a"
-  integrity sha512-mZl+LkiTI6ZHrtqXLcNT+vpsQ+k4Q1n2WI4uDdZVFktILwzbFWqfWPsETxty4io8R/FWBElRtCfq4arPI1sJXg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-elasticloadbalancingv2@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.63.0.tgz#60a7b2cf9568342f472fbdff286bf49bc953843a"
-  integrity sha512-yVCW8ocKaO6MpxUDtAqRhXNwYrrdu1G7VLP7AC5j4/RG/mj/OuyQpa8PXjioqvDuaBjJkxZ1T3UH6ZZfdpg7SQ==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.63.0"
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-ec2" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-lambda" "1.63.0"
-    "@aws-cdk/aws-s3" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/region-info" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-events@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.63.0.tgz#86c2833dbac8f558ec40d26d363e1668419000c1"
-  integrity sha512-9bltq/INjMxiCAahtk0QiI+953yk7EvhcA72VNdKmUVIjQsCIzwHwF78ojBtVEtTVrNpPrMKch+pomxjTKvwOg==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-iam@1.63.0", "@aws-cdk/aws-iam@^1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.63.0.tgz#5bea211498a81e2c7f19e7e7d335e663195af02d"
-  integrity sha512-d+kkz9I9v5an3RrsmOhXxyQLop/SB90YoDfmpd9JdKkDyMGSZN+e5IMvqye0iGC7rfA6tkVQb9tVEBdlXvZbZQ==
-  dependencies:
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/region-info" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-kms@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.63.0.tgz#7f04919cd826b24df0ab7513a3eab46492d96cfa"
-  integrity sha512-qeaq+5iwybkkiCmoO9M+x0ruXOxqF4UgGH0EN9FXrTRA5G+oXpu+SPjM94IA5mpSZLDukuqE17suPT3OPL3yIQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-lambda@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.63.0.tgz#efdd23cfaeb8182509772ef535a45a7470fb5ac9"
-  integrity sha512-dOvkAA2iYavTnXzccQzmN/QgIWPlfG0oLIdotgIVo/uXwXHeqIafNwiOkNVj5FM3YYU7iKKVh168iPj9C3/fng==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.63.0"
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.63.0"
-    "@aws-cdk/aws-ec2" "1.63.0"
-    "@aws-cdk/aws-efs" "1.63.0"
-    "@aws-cdk/aws-events" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-logs" "1.63.0"
-    "@aws-cdk/aws-s3" "1.63.0"
-    "@aws-cdk/aws-s3-assets" "1.63.0"
-    "@aws-cdk/aws-sqs" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/cx-api" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-logs@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.63.0.tgz#bf6093ffe8c3a6c135c931ac6c00aa2c9fcbc7a5"
-  integrity sha512-3i8zE5jLFu7sIQ/4n4+crP+PipQ0xNy1gc4lnwVZLEfG5kuXQmcUVFssG6twKnz986MGqDqPj0/eGKSRDgqccw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-s3-assets" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-route53@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.63.0.tgz#92394db3266e52621b1683e9e85665a58ef74da5"
-  integrity sha512-mimqxmWGH2K3pCwGP1nQ77W8+fivmKJaDRpYv6jX2kliL42WfFKlqm1yDrSdg82+HLTxUjpET374z45U4DrPLQ==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.63.0"
-    "@aws-cdk/aws-logs" "1.63.0"
-    "@aws-cdk/cloud-assembly-schema" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-s3-assets@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.63.0.tgz#111dcb4c426bcdfbfa9f090c6ff3174e07f917f2"
-  integrity sha512-jEASdZ84XBfZ8EVT9MAJh+ev54AGplzD0YAkNN1sMxM2ueGKEH4J8nO82tyEwzuEEyIRe6l1i0tRBkFekuhtNQ==
-  dependencies:
-    "@aws-cdk/assets" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/aws-s3" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    "@aws-cdk/cx-api" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-s3@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.63.0.tgz#770f2080e0233283ad43e2da01cac54f3118d3fe"
-  integrity sha512-IOb9oeLTavSxbM1UYgq+tei9kdpxZHmR8YztYnlahRJphetrI9q8XiayJ69yr60LHvojGTC6ATdpFB41vIwUqQ==
-  dependencies:
-    "@aws-cdk/aws-events" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-sns@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.63.0.tgz#4960cca7ce1a617ac1ae844363eddc6feecf85d8"
-  integrity sha512-x93WSxLhx5F/T5TZ/im/5QUwZRiHMOGqrsiNvEwbaqWoGCMbZOxLRn5Aqy8ApPUxHPs6//+ck9qwme1EFsO7TA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-events" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/aws-sqs" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-sqs@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.63.0.tgz#6ffa8eaeef44958475596107a6388de7a32d7a37"
-  integrity sha512-Y7UhpiwLUyB6wQA82DymmMkD5Vpqix9gHkst92T2wjKKNvWkJgsWV3hbpGxN22IaZnSljonwNU9UHSiDZkLG/Q==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.63.0"
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/aws-ssm@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.63.0.tgz#54b4e8b71a8c900e949af16f3b9fd7aaf821c410"
-  integrity sha512-yYI3TSczkcpIjaqkOX37UCjLLZ2YYe9ll/QF8xNCjrB0OSZgaptpOkayWOcLaGePG8aTGMQafeVGQr2BZ0n6VQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.63.0"
-    "@aws-cdk/aws-kms" "1.63.0"
-    "@aws-cdk/cloud-assembly-schema" "1.63.0"
-    "@aws-cdk/core" "1.63.0"
-    constructs "^3.0.4"
-
-"@aws-cdk/cloud-assembly-schema@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.63.0.tgz#e9653a947b1288c568f5844ef3488fbc2608e79f"
-  integrity sha512-5Pf23ahuGRuRrQ2Q8NkPY3H1zVIIM8yGwFOx3J/VA+cQHMcOSLcVSQXCEJuhRQgXnxkw4NqIyadERCrs4Jgbhg==
-  dependencies:
-    jsonschema "^1.2.5"
-    semver "^7.2.2"
-
-"@aws-cdk/core@1.63.0", "@aws-cdk/core@^1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.63.0.tgz#b69371706f66a141ab1e524c6b288788f3c14f1f"
-  integrity sha512-ADTBFy4Jm5Fa9yExnGNrhwmmmQ94FfPTRKGVkBouJzUB8+Q6xXxMynumUfo4Vh4oAliUdRWCSeQ6U238xctRaw==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.63.0"
-    "@aws-cdk/cx-api" "1.63.0"
-    constructs "^3.0.4"
-    fs-extra "^9.0.1"
-    minimatch "^3.0.4"
-
-"@aws-cdk/cx-api@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.63.0.tgz#977b1854b9c3f57faf268a6dc21a721969a405fd"
-  integrity sha512-ZehT06ySkMIq1j9Wpnw1hiWqKc0T5uOZLBTwCljnUmc9cr5cZnHQvy1fv3K7lr3nI3xcSNp1I0pMBw7KQXzIdQ==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.63.0"
-    semver "^7.2.2"
-
-"@aws-cdk/region-info@1.63.0":
-  version "1.63.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.63.0.tgz#a404049a59c7fc64ef2d36a30f4ed28691dbb14e"
-  integrity sha512-knjcOJRferLpYOaTWgNaA087Ttt/yKt1n7Uw3JkeKVbcnwKSzfVh4bXSxTaBzpxBWY61vhGJ+LznTThPQuV13w==
-
 "@babel/code-frame@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -685,11 +399,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
 aws-sdk@^2.610.0, aws-sdk@^2.656.0:
   version "2.731.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.731.0.tgz#a2564d882b943c2080d5100f5021088750cfb5f5"
@@ -1046,11 +755,6 @@ concat-stream@^1.6.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-constructs@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.0.4.tgz#eb1ed5b80f6600b8d50de83971357ae0fe8e29a2"
-  integrity sha512-CDvg7gMjphE3DFX4pzkF6j73NREbR8npPFW8Mx/CLRnMR035+Y1o1HrXIsNSss/dq3ZUnNTU9jKyd3fL9EOlfw==
 
 cookie@^0.3.1:
   version "0.3.1"
@@ -1643,16 +1347,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
-  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2125,24 +1819,10 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
-  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
-  dependencies:
-    universalify "^1.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-1.0.1.tgz#ea5efe40b83690b98667614a7392fc60e842c0dd"
   integrity sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0=
-
-jsonschema@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.6.tgz#52b0a8e9dc06bbae7295249d03e4b9faee8a0c0b"
-  integrity sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -2909,7 +2589,7 @@ semver@^6.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.2, semver@^7.3.2:
+semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -3277,11 +2957,6 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-universalify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
-  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 untildify@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What does this change?

Trello card: https://trello.com/c/F1DtzUvo/2046-implement-prodmons-3-attempt-behaviour-to-cypress-integration-tests

This PR adds Cloudwatch alarms to each suite of the integration tests. Now that we're [sending test results as metrics to Cloudwatch](https://github.com/guardian/editorial-tools-integration-tests/pull/84), we can create alarms in Cloudwatch that are a bit more lenient towards failures.

The alarms configured here only fire when **3 out of 10 test runs fail for a given suite**. This means we will allow for sporadic failures but not consistent ones, very much like how ProdMon behaves.

## How can we measure success?

We cut out all noise from random failures that immediately resolve straight after!

## Do the relevant integration tests still pass?

- [X] Tested against ALL PROD