### PR TITLE
Log the suite and UID in all logs

### DIFF
--- a/reporters/reporter.ts
+++ b/reporters/reporter.ts
@@ -23,7 +23,7 @@ const runIDFile = `${tmpDir}/${suite}.id.txt`;
 // Yields `YYYY-DD-MMTHH-MM`
 const uid = new Date().toISOString().substr(0, 16);
 
-const logger = new Logger({ logDir, logFile });
+const logger = new Logger({ logDir, logFile, uid, suite });
 
 module.exports = Reporter;
 
@@ -46,10 +46,7 @@ function Reporter(runner: Mocha.Runner) {
 
       // Create run ID file that can be used by `uploadVideo.ts`
       fs.writeFileSync(runIDFile, uid);
-      logger.log({
-        message: `Started - ${suite} with uid ${uid}`,
-        uid,
-      });
+      logger.log({ message: `Started - ${suite} with uid ${uid}` });
     });
 
     runner.on('pending', async function (test) {
@@ -57,7 +54,6 @@ function Reporter(runner: Mocha.Runner) {
       passes++;
       console.log('Pending:', test.fullTitle());
       logger.log({
-        uid,
         testTitle: test.title,
         message,
         testContext: test.titlePath()[0],
@@ -71,7 +67,6 @@ function Reporter(runner: Mocha.Runner) {
       passes++;
       console.log('Pass:', test.fullTitle());
       logger.log({
-        uid,
         testTitle: test.title,
         message,
         testContext: test.titlePath()[0],
@@ -86,7 +81,6 @@ function Reporter(runner: Mocha.Runner) {
       failures++;
       console.error('Failure:', test.fullTitle(), err.message, '\n');
       logger.error({
-        uid,
         video,
         message,
         testTitle: test.title,
@@ -101,16 +95,12 @@ function Reporter(runner: Mocha.Runner) {
     runner.on('end', async function () {
       console.log('end: %d/%d', passes, passes + failures);
       fs.writeFileSync(failuresFile, failures.toString());
-      logger.log({
-        message: `Ended - ${suite} with uid ${uid}`,
-        uid,
-      });
+      logger.log({ message: `Ended - ${suite} with uid ${uid}` });
     });
   } catch (e) {
     logger.error({
       message: `Error - ${suite} [${uid}]: ${e.message}`,
       stackTrace: e.stack,
-      uid,
     });
   }
 }

--- a/scripts/uploadVideo.ts
+++ b/scripts/uploadVideo.ts
@@ -20,7 +20,7 @@ const month = now.getMonth() + 1;
 const date = now.getDate();
 
 (async function f() {
-  const logger = new Logger({ logDir, logFile });
+  const logger = new Logger({ logDir, logFile, suite });
   let uid: string | null = null;
 
   try {
@@ -34,6 +34,8 @@ const date = now.getDate();
     });
     return;
   }
+
+  logger.setUid(uid);
 
   try {
     const failures = Number(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,11 +5,29 @@ type LogData = { [key: string]: any };
 
 export class Logger {
   file: string;
-  constructor({ logDir, logFile }: { logDir: string; logFile: string }) {
+  private uid: string | undefined;
+  private suite: string | undefined;
+  constructor({
+    logDir,
+    logFile,
+    uid,
+    suite,
+  }: {
+    logDir: string;
+    logFile: string;
+    uid?: string;
+    suite?: string;
+  }) {
+    this.uid = uid;
+    this.suite = suite;
     this.file = path.join(logDir, logFile);
     if (!fs.existsSync(logDir)) {
       fs.mkdirSync(logDir, { recursive: true });
     }
+  }
+
+  setUid(uid: string) {
+    this.uid = uid;
   }
 
   executionDate() {
@@ -20,6 +38,8 @@ export class Logger {
     return JSON.stringify({
       level,
       ...json,
+      suite: process.env.SUITE || this.suite || 'unknown',
+      uid: process.env.UID || this.uid || 'unknown',
       testExecutionTime: this.executionDate(),
     });
   }


### PR DESCRIPTION
## What does this change?

The term `suite` has become the common way to refer to the application the tests are running against, such as 'grid', 'workflow' and 'composer'. It's therefore useful to have this explicitly captured in the logs, especially once the app name becomes unspecific after #91 . Similarly, the UID is currently logged everywhere, but manually.

This PR adds the suite and UID as log lines wherever possible by abstracting the fields to the Logger class, rather than manually passing them in at every opportunity. 

## How can we measure success?

We can filter logs more easily by test suite.

## Do the relevant integration tests still pass?

- [X] Tested against CODE ALL
