### PR TITLE
Further increase test run frequency and log how long tests take to run

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -26,6 +26,7 @@ import { UrlSubscription } from '@aws-cdk/aws-sns-subscriptions';
 const SUITES = ['Grid', 'Composer', 'Workflow'];
 const APP_NAME = 'editorial-tools-integration-tests';
 const DIST_BUCKET = `${APP_NAME}-dist`;
+const CRON_FREQUENCY = 4; // number in minutes
 
 export class CdkStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -254,7 +255,7 @@ systemctl start logstash
           files: {
             '/etc/cron.d/run-integration-tests': {
               content: `
-*/4 * * * * root /data/${enrichedAppName}/scripts/run.sh ${stage} ${suite.toLowerCase()} >> /var/log/tests.log 2>&1
+*/${CRON_FREQUENCY} * * * * root /data/${enrichedAppName}/scripts/run.sh ${stage} ${suite.toLowerCase()} >> /var/log/tests.log 2>&1
 `,
             },
             '/etc/logstash/conf.d/logstash.conf': {

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -26,7 +26,7 @@ import { UrlSubscription } from '@aws-cdk/aws-sns-subscriptions';
 const SUITES = ['Grid', 'Composer', 'Workflow'];
 const APP_NAME = 'editorial-tools-integration-tests';
 const DIST_BUCKET = `${APP_NAME}-dist`;
-const CRON_FREQUENCY = 4; // number in minutes
+const CRON_FREQUENCY = 3; // number in minutes
 
 export class CdkStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -323,7 +323,7 @@ systemctl start logstash
           suite: suite.toLowerCase(),
           stage: 'PROD',
         },
-        period: Duration.minutes(4),
+        period: Duration.minutes(CRON_FREQUENCY),
         statistic: 'Maximum',
       });
 

--- a/reporters/reporter.ts
+++ b/reporters/reporter.ts
@@ -20,7 +20,8 @@ const logFile = 'tests.json.log';
 const failuresFile = `${tmpDir}/${suite}.failures.txt`;
 const runIDFile = `${tmpDir}/${suite}.id.txt`;
 // Yields `YYYY-DD-MMTHH-MM`
-const uid = new Date().toISOString().substr(0, 16);
+const start = new Date();
+const uid = start.toISOString().substr(0, 16);
 
 const logger = new Logger({ logDir, logFile, uid, suite });
 
@@ -92,9 +93,16 @@ function Reporter(runner: Mocha.Runner) {
     });
 
     runner.on('end', async function () {
+      const end = new Date();
+      const diffInSeconds = (
+        Math.abs(end.getTime() - start.getTime()) / 1000
+      ).toFixed(2);
       console.log('end: %d/%d', passes, passes + failures);
       fs.writeFileSync(failuresFile, failures.toString());
-      logger.log({ message: `Ended - ${suite} with uid ${uid}` });
+      logger.log({
+        message: `Ended - ${suite} with uid ${uid} (took ${diffInSeconds} seconds)`,
+        testRuntime: diffInSeconds,
+      });
     });
   } catch (e) {
     logger.error({

--- a/reporters/reporter.ts
+++ b/reporters/reporter.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 
 import { Logger } from '../src/utils/logger';
-import env from '../env.json';
 import {
   generateMessage,
   putMetric,


### PR DESCRIPTION
## What does this change?

Having looked at the logs of the tests, it has become clear that none of the suites run for more than around 1.5 minutes. This means we can increase the test frequency to every 3 minutes, rather than every 4, creating an even quicker lead time (9 minutes of failures before alert instead of 12) if things go wrong. Since we're now using AWS CDK, we can thankfully automatically adapt the alerts to match the frequency of our crons, which is neat!

In order to observe test run times more easily in the future, this PR also adds logging for how long in seconds the test suites run.

## How can we measure success?

We get alerted more quickly to actual failures and we can observe run times more easily in the future.

- [x] Tested against CODE