### PR TITLE
Add cloudformation to RiffRaff deployments

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -16,6 +16,11 @@
       "action": "editorial-tools-integration-tests-composer",
       "path": "./",
       "compress": "zip"
+    },
+    {
+      "action": "cloudformation",
+      "path": "cloudformation/cdk/CdkStack.template.json",
+      "compress": false
     }
   ]
 }

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -25,3 +25,11 @@ deployments:
         Recipe: editorial-tools-cypress-integration-tests
         AmigoStage: PROD
         BuiltBy: amigo
+  cloudformation:
+    type: cloud-formation
+    app: editorial-tools-integration-tests
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: editorial-tools-integration-tests
+      templatePath: cloudformation.json
+      cloudFormationStackByTags: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -31,5 +31,5 @@ deployments:
     parameters:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: editorial-tools-integration-tests
-      templatePath: cloudformation.json
+      templatePath: CdkStack.template.json
       cloudFormationStackByTags: false

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${DIR}/.."
+
 echo "##teamcity[blockOpened name='npm']"
 yarn
 echo "##teamcity[blockClosed name='npm']"
@@ -9,6 +12,10 @@ echo "##teamcity[blockClosed name='npm']"
 echo "##teamcity[testSuiteStarted name='lint']"
 yarn lint
 echo "##teamcity[testSuiteFinished name='lint']"
+
+echo "##teamcity[blockOpened name='generate-cfn']"
+"${ROOT_DIR}/scripts/generate-cfn.sh"
+echo "##teamcity[blockClosed name='generate-cfn']"
 
 echo "##teamcity[compilationStarted compiler='riffraff']"
 yarn riffraff


### PR DESCRIPTION
## What does this change?

This PR ensures that any changes to the app infrastructure is deployed via RiffRaff!

## How can we measure success?

Any changes to the AWS infrastructure through the CDK files get deployed to RiffRaff, ensuring the state always matches what the codebase says it should be.