### PR TITLE
Clean up the repository and README

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,6 @@
   "description": "",
   "scripts": {
     "test": "./scripts/setup.sh $ENV && yarn cy:run-dev",
-    "grid-prod": "APP=grid STAGE=prod yarn start",
-    "grid-code": "APP=grid STAGE=test yarn start",
-    "grid-test": "APP=grid STAGE=test yarn start",
-    "grid-local": "APP=grid STAGE=local yarn start",
-    "composer-prod": "APP=composer STAGE=prod yarn start",
-    "composer-code": "APP=composer STAGE=code yarn start",
-    "composer-local": "APP=composer STAGE=local yarn start",
     "start": "cypress run --reporter spec --env APP=$APP,STAGE=$STAGE --spec cypress/integration/$APP/*",
     "cy:live": "cypress run --env APP=$SUITE,STAGE=$STAGE --spec cypress/integration/$SUITE/*",
     "cy:run-dev": "cypress run --reporter spec",

--- a/scripts/fetch-config.sh
+++ b/scripts/fetch-config.sh
@@ -4,9 +4,10 @@ set -e
 
 STAGE=${1:-LOCAL}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ACCOUNT="media-service"
 
 if [[ ${STAGE} != "PROD"  ]]; then
-    aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json --profile media-service
+    aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json --profile "${ACCOUNT}"
 else
     aws s3 cp s3://editorial-tools-integration-tests-dist/env.dev.json ${DIR}/../env.json
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,32 +4,25 @@ set -e
 
 STAGE=${1:-LOCAL}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
+ACCOUNT="media-service"
 
 bold='\x1B[0;1m'
 green='\x1B[0;32m'
 red='\x1B[0;31m'
 plain='\x1B[0m' # No Color
 
-checkForNodeModules() {
-  if [[ ! -d ${DIR}/../node_modules ]]; then
-    echo -e "${red}No node_modules found, please run yarn.${plain}"
-    exit 1
-  fi
-}
-
 checkIfAbleToTalkToAWS() {
   if [[ ${STAGE} != "PROD" ]]; then
-    STATUS=$(aws sts get-caller-identity --profile media-service 2>&1 || true)
+    STATUS=$(aws sts get-caller-identity --profile ${ACCOUNT} 2>&1 || true)
   else
     STATUS=$(aws sts get-caller-identity 2>&1 || true)
   fi
 
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-    echo -e "${red}Credentials for the media-service profile are expired. Please fetch new credentials and run this again.${plain}"
+    echo -e "${red}Credentials for the ${ACCOUNT} profile are expired. Please fetch new credentials and run this again.${plain}"
     exit 1
   elif [[ ${STATUS} =~ ("could not be found") ]]; then
-    echo -e "${red}Credentials for the media-service profile are missing. Please ensure you have the right credentials.${plain}"
+    echo -e "${red}Credentials for the ${ACCOUNT} profile are missing. Please ensure you have the right credentials.${plain}"
     exit 1
   fi
 }
@@ -40,6 +33,6 @@ fetchEnv() {
     fi
 }
 
-checkForNodeModules
 checkIfAbleToTalkToAWS
+yarn --silent # install node dependencies
 fetchEnv


### PR DESCRIPTION
This PR makes a couple of small improvements to the README, scripts and infrastructure files:

* Abstract stack name wherever possible to make it easier to change in the future
* Always install node modules via yarn (as it takes no time to run if already installed)
* Remove unused npm scripts (now that `scripts/start.sh` is standard)
* Update README

These are almost all refactors, and should not impact the running of the app in any way.
