### PR TITLE
Fully qualify reference to yarn in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,5 +34,5 @@ fetchEnv() {
 }
 
 checkIfAbleToTalkToAWS
-yarn --silent # install node dependencies
+/usr/local/bin/yarn --silent # install node dependencies
 fetchEnv


### PR DESCRIPTION
## What does this change?

At the moment, integration tests are not running in production, as `crontab` does not include yarn's location in `$PATH`. (There is no path 🥄 )

#95 introduces the `yarn` install, which isn't required in production – a subsequent PR should remove this command, and possibly the rest of the setup script, as its other components don't seem to be necessary either (the env.json is taken care of in CDK, and we don't need to worry about AWS creds on an AWS box).

This PR fully qualifies reference to `yarn` in setup script to prevent this from happening.

## How can we measure success?

Our tests begin running again.

## Do the relevant integration tests still pass?

- [ ] Tested against <STAGE> <APP|APPS>
