### PR TITLE
Treats missing data as "IGNORE" for integration alarms

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -337,7 +337,7 @@ systemctl start logstash
         metric: metric,
         threshold: 1,
         actionsEnabled: true,
-        treatMissingData: TreatMissingData.MISSING,
+        treatMissingData: TreatMissingData.IGNORE,
       });
       alarm.addAlarmAction(snsAction);
       alarm.addOkAction(snsAction);


### PR DESCRIPTION
## What does this change?
We have noticed that the Workflow alarms have been quite noisy lately, this seems to be unrelated to actual failures. This PR changes the alarm to treat missing data as "IGNORE". This will maintain the current state of the alarm regardless of missing data. 

This change should be safe as the alerts we've had have not been corroborated by user reports and are unlikely to be legitimate problems. 

## How can we measure success?
The alarms only alert when a real problem occurs.
