### PR TITLE
Mitigates the log4j vulnerability by removing the affected class

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -243,6 +243,8 @@ npm install --global yarn
 aws s3 cp s3://${DIST_BUCKET}/env.json /data/${enrichedAppName}/env.json
 
 # Set up logstash
+# https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476
+zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.* org/apache/logging/log4j/core/lookup/JndiLookup.class
 systemctl start logstash
 `);
       const launchConfiguration = new CfnLaunchConfiguration(


### PR DESCRIPTION
## What does this change?
This PR updates the project CDK to mitigate a Log4j vulnerability. Using the steps command recommend by the Elastic Search team: https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476

This has also been done in other projects with a similar setup: https://github.com/guardian/deploy-tools-platform/pull/562

## How can we measure success?

We have eliminated possible log4j vulnerabilities.

## Do the relevant integration tests still pass?

- [x] Tested against PROD
