### PR TITLE
Fixes for grid integration tests

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -154,7 +154,9 @@ describe('Grid Key User Journeys', function () {
     image.editRights('screengrab', date);
     image.editDescription(date);
     image.editByline(date);
-    image.editCredit(date);
+    // TODO credit is already `date` and UI regression means that no-op edits will break image page
+    // when regression is fixed remove this `+ '1'`
+    image.editCredit(date + '1');
     image.editCopyright(date);
     image.addLabel(date);
     image.removeLabel(date);

--- a/cypress/utils/grid/api.ts
+++ b/cypress/utils/grid/api.ts
@@ -38,7 +38,7 @@ export async function deleteImages(
 
     cy.wait(500);
 
-    const url = `${getDomain(grid, { prefix: 'api' })}/images/${id}`;
+    const url = `${getDomain(grid, { prefix: 'api' })}/images/${id}/hard-delete`;
     cy.request({
       method: 'DELETE',
       url,

--- a/cypress/utils/grid/image.ts
+++ b/cypress/utils/grid/image.ts
@@ -11,7 +11,7 @@ export function editRights(rightsType: string, usage: string) {
 
 export function editDescription(description: string) {
   cy.get('[data-cy=it-edit-description-button]').click({ force: true });
-  cy.get('[data-cy=metadata-description] .editable-has-buttons')
+  cy.get('[data-cy=metadata-description] .editable-input')
     .clear()
     .type(description);
   cy.get('[data-cy=metadata-description] .editable-buttons > .button-save')
@@ -55,11 +55,11 @@ export function addLabel(name: string) {
   cy.get('.gr-add-label__form__buttons__button-save')
     .click()
     .should('not.exist');
-  cy.get('.labeller').contains(name, { timeout: 10000 }).should('exist');
+  cy.get('.labels').contains(name, { timeout: 10000 }).should('exist');
 }
 
 export function removeLabel(date: string) {
-  cy.get('.labeller')
+  cy.get('.labels')
     .contains(date)
     .parent()
     .find('[data-cy=it-remove-label-button]')


### PR DESCRIPTION
## What does this change?

Fixes for the currently broken grid integration tests. Also requires guardian/grid#3595

* Change the deletion endpoint to use `hard-delete` - this ensures that the tests exercise the image upload process, rather than the undeletion process.
* Updates some selectors to match new class names
* Adds a temporary workaround for regression in grid UI which causes UI degradation when attempting to save edits that have no changes

## How can we measure success?

Grid integration tests go green

## Do the relevant integration tests still pass?

- [x] Tested against TEST grid (with guardian/grid#3595)
