### PR TITLE
Alter setup script to find yarn correctly with new AMI

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -235,7 +235,6 @@ aws s3 cp s3://${DIST_BUCKET}/${stack}/${stage}/${enrichedAppName}/${enrichedApp
 unzip -q /tmp/${enrichedAppName}.zip -d /data/${enrichedAppName}
 
 # Install Cypress dependencies
-npm install --global yarn
 /data/${enrichedAppName}/node_modules/cypress/bin/cypress install
 
 

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "video": true,
-  "reporter": "reporters/reporter.ts",
+  "reporter": "reporters/reporter.js",
   "viewportWidth": 1280,
   "viewportHeight": 720,
   "videoCompression": false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cy:open": "cypress open --env APP=$APP,STAGE=$STAGE",
     "lint": "eslint cypress/integration/* src/* reporters --ext .ts --ext .js",
     "riffraff": "node-riffraff-artifact",
-    "upload-video": "ts-node scripts/uploadVideo.ts"
+    "upload-video": "node scripts/uploadVideo.js"
   },
   "keywords": [],
   "author": "",

--- a/reporters/reporter.js
+++ b/reporters/reporter.js
@@ -1,13 +1,13 @@
-import mocha from 'mocha';
-import fs from 'fs';
-import path from 'path';
+const mocha = require('mocha');
+const fs = require('fs');
+const path = require('path');
 
-import { Logger } from '../src/utils/logger';
-import {
+const { Logger } = require('../src/utils/logger');
+const {
   generateMessage,
   putMetric,
   getVideoName,
-} from '../src/utils/reporters';
+} = require('../src/utils/reporters');
 const suite = process.env.SUITE;
 
 if (!suite) {
@@ -27,7 +27,7 @@ const logger = new Logger({ logDir, logFile, uid, suite });
 
 module.exports = Reporter;
 
-function Reporter(runner: Mocha.Runner) {
+function Reporter(runner) {
   // @ts-ignore
   mocha.reporters.Base.call(this, runner);
   let passes = 0;
@@ -77,7 +77,7 @@ function Reporter(runner: Mocha.Runner) {
 
     runner.on('fail', async function (test, err) {
       const message = generateMessage('Failure', test);
-      const video = getVideoName(<Mocha.Suite>test.parent); // TODO: Think of a way to surface this information in CW so that we can correlate alarms, logs and metrics
+      const video = getVideoName(test.parent); // TODO: Think of a way to surface this information in CW so that we can correlate alarms, logs and metrics
       failures++;
       console.error('Failure:', test.fullTitle(), err.message, '\n');
       logger.error({
@@ -112,5 +112,4 @@ function Reporter(runner: Mocha.Runner) {
   }
 }
 
-// @ts-ignore
 mocha.utils.inherits(Reporter, mocha.reporters.Spec);

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,8 +22,8 @@ function runTests() {
     REALSTAGE=$STAGE
   fi
 
-  SUITE=${SUITE} STAGE="${REALSTAGE}" npm run --silent cy:live || true
-  SUITE=${SUITE} STAGE="${REALSTAGE}" npm run upload-video
+  SUITE=${SUITE} STAGE="${REALSTAGE}" /usr/local/node/yarn run --silent cy:live || true
+  SUITE=${SUITE} STAGE="${REALSTAGE}" /usr/local/node/yarn run upload-video
 }
 
 resetTmpFiles

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PATH=/usr/local/node:$PATH
+
 STAGE=${1:-PROD}
 SUITE=$2
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -22,8 +24,8 @@ function runTests() {
     REALSTAGE=$STAGE
   fi
 
-  SUITE=${SUITE} STAGE="${REALSTAGE}" /usr/local/node/yarn run --silent cy:live || true
-  SUITE=${SUITE} STAGE="${REALSTAGE}" /usr/local/node/yarn run upload-video
+  SUITE=${SUITE} STAGE="${REALSTAGE}" yarn run --silent cy:live || true
+  SUITE=${SUITE} STAGE="${REALSTAGE}" yarn run upload-video
 }
 
 resetTmpFiles

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,5 +34,5 @@ fetchEnv() {
 }
 
 checkIfAbleToTalkToAWS
-/usr/local/bin/yarn --silent # install node dependencies
+/usr/local/node/yarn --silent # install node dependencies
 fetchEnv

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PATH=/usr/local/node:$PATH
+
 STAGE=${1:-LOCAL}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ACCOUNT="media-service"
@@ -34,5 +36,5 @@ fetchEnv() {
 }
 
 checkIfAbleToTalkToAWS
-/usr/local/node/yarn --silent # install node dependencies
+yarn --silent # install node dependencies
 fetchEnv

--- a/scripts/uploadVideo.js
+++ b/scripts/uploadVideo.js
@@ -1,9 +1,9 @@
-import AWS from 'aws-sdk';
-import path from 'path';
-import fs from 'fs';
-import { Logger } from '../src/utils/logger';
-import { uploadVideoToS3 } from '../src/utils/s3';
-import config from '../env.json';
+const AWS = require('aws-sdk');
+const path = require('path');
+const fs = require('fs');
+const { Logger } = require('../src/utils/logger');
+const { uploadVideoToS3 } = require('../src/utils/s3');
+const config = require('../env.json');
 
 const suite = process.env.SUITE;
 
@@ -21,7 +21,7 @@ const date = now.getDate();
 
 (async function f() {
   const logger = new Logger({ logDir, logFile, suite });
-  let uid: string | null = null;
+  let uid = null;
 
   try {
     uid = fs.readFileSync(idFile, { encoding: 'utf8' });

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,22 +1,16 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
-type LogData = { [key: string]: any };
+class Logger {
+  file;
+  uid;
+  suite;
 
-export class Logger {
-  file: string;
-  private uid: string | undefined;
-  private suite: string | undefined;
   constructor({
     logDir,
     logFile,
     uid,
     suite,
-  }: {
-    logDir: string;
-    logFile: string;
-    uid?: string;
-    suite?: string;
   }) {
     this.uid = uid;
     this.suite = suite;
@@ -26,7 +20,7 @@ export class Logger {
     }
   }
 
-  setUid(uid: string) {
+  setUid(uid) {
     this.uid = uid;
   }
 
@@ -34,7 +28,7 @@ export class Logger {
     return new Date().toISOString();
   }
 
-  prepopulated(json: LogData, level: string) {
+  prepopulated(json, level) {
     return JSON.stringify({
       level,
       ...json,
@@ -44,13 +38,15 @@ export class Logger {
     });
   }
 
-  log(json: LogData) {
+  log(json) {
     const data = this.prepopulated(json, 'INFO');
     fs.appendFileSync(this.file, data + '\n');
   }
 
-  error(json: LogData) {
+  error(json) {
     const data = this.prepopulated(json, 'ERROR');
     fs.appendFileSync(this.file, data + '\n');
   }
 }
+
+module.exports = { Logger }

--- a/src/utils/reporters.js
+++ b/src/utils/reporters.js
@@ -50,5 +50,6 @@ async function getCloudWatchClient(credentials) {
 
 module.exports = {
   generateMessage,
-  putMetric
+  putMetric,
+  getVideoName
 }

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -1,22 +1,15 @@
-import AWS from 'aws-sdk';
-import fs from 'fs';
+const AWS = require('aws-sdk');
+const fs = require('fs');
 
-type MaybeCredentials = AWS.SharedIniFileCredentials | undefined;
-
-export async function getS3Client(credentials: MaybeCredentials) {
+async function getS3Client(credentials) {
   return credentials ? new AWS.S3({ credentials }) : new AWS.S3();
 }
 
-export async function uploadVideoToS3({
+async function uploadVideoToS3({
   credentials,
   file,
   bucket,
   key,
-}: {
-  credentials: MaybeCredentials;
-  file: string;
-  bucket: string;
-  key: string;
 }) {
   const s3 = await getS3Client(credentials);
   const videoData = fs.readFileSync(file);
@@ -28,4 +21,9 @@ export async function uploadVideoToS3({
     })
     .promise()
     .catch((err) => console.error(err));
+}
+
+module.exports = {
+  getS3Client,
+  uploadVideoToS3
 }


### PR DESCRIPTION
## What does this change?

This PR makes a few changes necessary as a result of #124 to get integration tests working:

- Alter setup script to find yarn correctly with a [new AMI configuration](https://amigo.gutools.co.uk/recipes/editorial-tools-cypress-integration-tests/bakes/113).
- Move some Cypress infra scripts from TS to JS to work around https://github.com/cypress-io/cypress/issues/8617.

## How can we measure success?

Our integration tests run once more.

## Do the relevant integration tests still pass?

Tested by running in PROD:

```
ubuntu@ip-172-31-10-159:~$ tail -f /var/log/tests.log 

       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  composer/integration.ts                  02:23        4        4        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        02:23        4        4        -        -        -  
```
