### PR TITLE
Avoid low-impact bug in Grid cropping

### DIFF
--- a/cypress/integration/grid/keyUserJourneys.spec.ts
+++ b/cypress/integration/grid/keyUserJourneys.spec.ts
@@ -54,7 +54,7 @@ describe('Grid Key User Journeys', function () {
     const crop = {
       width: '900',
       height: '540',
-      xValue: '1020',
+      xValue: '500',
       yValue: '581',
     };
 


### PR DESCRIPTION
## What does this change?

There seems to be a bug in the Grid's cropping functionality, that in some circumstances entering an x-coordinate into the cropping form will result in x-1 being applied. We've been unable to replicate outside of the cypress environment (and even then, only on the deployed test runners), and we believe that primary usage of the cropping tool is to use the UI handles, not the coordinate entry boxes. Picking a different value for the test's x-coordinate seems to avoid this bug, allowing the tests to run as usual again.

Worth noting that this has happened before - #27 - but that temporary measure has since been removed and it's not entirely clear what changed, possibly an upgrade to cypress that has since been undone.

We could/should investigate the cause of this bug in Grid, but since we have been unable to replicate locally and the impact seems to be low, we have chosen to avoid the problem in the tests as a tactical choice, allowing the tests to run again and watch for higher severity issues.

## How can we measure success?

Integration tests pass.

## Do the relevant integration tests still pass?

- [x] Tested against TEST Grid

## Images
